### PR TITLE
extend branch workflow tests to include relationship delete

### DIFF
--- a/packages/transformer/src/test/TestUtils/TimelineTestUtil.ts
+++ b/packages/transformer/src/test/TestUtils/TimelineTestUtil.ts
@@ -10,11 +10,12 @@ import {
   PhysicalObject, PhysicalPartition, SpatialCategory,
 } from "@itwin/core-backend";
 
-import { ChangesetIdWithIndex, Code, ElementProps, IModel, PhysicalElementProps, SubCategoryAppearance } from "@itwin/core-common";
+import { ChangesetIdWithIndex, Code, ElementProps, IModel, PhysicalElementProps, RelationshipProps, SubCategoryAppearance } from "@itwin/core-common";
 import { Point3d, YawPitchRollAngles } from "@itwin/core-geometry";
 import { IModelTransformer } from "../../transformer";
 import { HubWrappers, IModelTransformerTestUtils } from "../IModelTransformerUtils";
 import { IModelTestUtils } from "./IModelTestUtils";
+import { omit } from "@itwin/core-bentley";
 
 const { count, saveAndPushChanges } = IModelTestUtils;
 
@@ -34,15 +35,38 @@ export function getIModelState(db: IModelDb): TimelineIModelElemState {
 
   for (const elemId of elemIds) {
     const elem = db.elements.getElement(elemId);
-    if (elem.userLabel && elem.userLabel in result)
+    const tag = elem.userLabel ?? elem.id;
+    if (tag in result)
       throw Error("timelines only support iModels with unique user labels");
     const isSimplePhysicalObject = elem.jsonProperties.updateState !== undefined;
 
-    result[elem.userLabel ?? elem.id]
-      = isSimplePhysicalObject
-        ? elem.jsonProperties.updateState
-        : elem.toJSON();
+    result[tag] = isSimplePhysicalObject ? elem.jsonProperties.updateState : elem.toJSON();
   }
+
+  const supportedRelIds = db.withPreparedStatement(`
+    SELECT erte.ECInstanceId, erte.ECClassId,
+        se.ECInstanceId AS SourceId, se.UserLabel AS SourceUserLabel,
+        te.ECInstanceId AS TargetId, te.UserLabel AS TargetUserLabel
+    FROM Bis.ElementRefersToElements erte
+    JOIN Bis.Element se
+      ON se.ECInstanceId=erte.SourceECInstanceId
+    JOIN Bis.Element te
+      ON te.ECInstanceId=erte.TargetECInstanceId
+  `, (s) => [...s]);
+
+  for (const {
+    id, className,
+    sourceId, sourceUserLabel,
+    targetId, targetUserLabel,
+  } of supportedRelIds) {
+    const relProps = db.relationships.getInstanceProps(className, id);
+    const tag = `REL_${sourceUserLabel ?? sourceId}_${targetUserLabel ?? targetId}_${className}`;
+    if (tag in result)
+      throw Error("timelines only support iModels with unique user labels");
+
+    result[tag] = omit(relProps, ["id"]);
+  }
+
   return result;
 }
 
@@ -61,7 +85,7 @@ export function populateTimelineSeed(db: IModelDb, state?: TimelineIModelElemSta
   SpatialCategory.insert(db, IModel.dictionaryId, "SpatialCategory", new SubCategoryAppearance());
   PhysicalModel.insert(db, IModel.rootSubjectId, "PhysicalModel");
   if (state)
-    maintainPhysicalObjects(db, state);
+    maintainObjects(db, state);
   db.performCheckpoint();
 }
 
@@ -69,11 +93,20 @@ export function assertElemState(db: IModelDb, state: TimelineIModelElemStateDelt
   expect(getIModelState(db)).to.deep.subsetEqual(state, { useSubsetEquality: subset });
 }
 
-export function maintainPhysicalObjects(iModelDb: IModelDb, delta: TimelineIModelElemStateDelta): void {
+function maintainObjects(iModelDb: IModelDb, delta: TimelineIModelElemStateDelta): void {
   const modelId = iModelDb.elements.queryElementIdByCode(PhysicalPartition.createCode(iModelDb, IModel.rootSubjectId, "PhysicalModel"))!;
   const categoryId = iModelDb.elements.queryElementIdByCode(SpatialCategory.createCode(iModelDb, IModel.dictionaryId, "SpatialCategory"))!;
 
   for (const [elemName, upsertVal] of Object.entries(delta)) {
+    const isRel = (d: TimelineElemDelta): d is RelationshipProps =>
+      (d as RelationshipProps).sourceId !== undefined;
+
+    if (isRel(upsertVal))
+      throw Error(
+        "adding relationships to the small delta format is not supported"
+        + "use a `manualUpdate` step instead"
+      );
+
     const [id] = iModelDb.queryEntityIds({ from: "Bis.Element", where: "UserLabel=?", bindings: [elemName] });
 
     if (upsertVal === deleted) {
@@ -113,8 +146,8 @@ export function maintainPhysicalObjects(iModelDb: IModelDb, delta: TimelineIMode
   iModelDb.saveChanges();
 }
 
-export type TimelineElemState = number | Omit<ElementProps, "userLabel">;
-export type TimelineElemDelta = number | TimelineElemState | typeof deleted;
+export type TimelineElemState = number | Omit<ElementProps, "userLabel"> | RelationshipProps;
+export type TimelineElemDelta = TimelineElemState | typeof deleted;
 
 export interface TimelineIModelElemStateDelta {
   [name: string]: TimelineElemDelta;
@@ -256,7 +289,7 @@ export async function runTimeline(timeline: Timeline, { iTwinId, accessToken }: 
           await maybeManualUpdate(newIModelDb);
           newTrackedIModel.state = getIModelState(newIModelDb);
         } else
-          maintainPhysicalObjects(newIModelDb, newIModelEvent as TimelineIModelElemStateDelta);
+          maintainObjects(newIModelDb, newIModelEvent as TimelineIModelElemStateDelta);
         await saveAndPushChanges(accessToken, newIModelDb, `new with state [${newIModelEvent}] at point ${i}`);
       }
 
@@ -314,7 +347,7 @@ export async function runTimeline(timeline: Timeline, { iTwinId, accessToken }: 
         } else {
           const delta = event;
           alreadySeenIModel.state = applyDelta(alreadySeenIModel.state, delta);
-          maintainPhysicalObjects(alreadySeenIModel.db, delta);
+          maintainObjects(alreadySeenIModel.db, delta);
           stateMsg = `${iModelName} becomes: ${JSON.stringify(alreadySeenIModel.state)}, `
             + `delta: [${JSON.stringify(delta)}], at ${i}`;
         }

--- a/packages/transformer/src/test/standalone/IModelTransformerHub.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformerHub.test.ts
@@ -8,13 +8,13 @@ import * as path from "path";
 import * as semver from "semver";
 import {
   BisCoreSchema, BriefcaseDb, BriefcaseManager, CategorySelector, deleteElementTree, DisplayStyle3d, Element, ElementGroupsMembers, ElementOwnsChildElements, ElementRefersToElements,
-  ExternalSourceAspect, GenericSchema, GraphicalElement3dRepresentsElement, HubMock, IModelDb, IModelHost, IModelJsFs, IModelJsNative, ModelSelector, NativeLoggerCategory, PhysicalModel,
+  ExternalSourceAspect, GenericSchema, HubMock, IModelDb, IModelHost, IModelJsFs, IModelJsNative, ModelSelector, NativeLoggerCategory, PhysicalModel,
   PhysicalObject, SnapshotDb, SpatialCategory, SpatialViewDefinition, Subject,
 } from "@itwin/core-backend";
 
 import * as TestUtils from "../TestUtils";
 import { AccessToken, Guid, GuidString, Id64, Id64String, Logger, LogLevel } from "@itwin/core-bentley";
-import { Code, ColorDef, ElementProps, IModel, IModelVersion, RelationshipProps, SubCategoryAppearance } from "@itwin/core-common";
+import { Code, ColorDef, ElementProps, IModel, IModelVersion, SubCategoryAppearance } from "@itwin/core-common";
 import { Point3d, YawPitchRollAngles } from "@itwin/core-geometry";
 import { IModelExporter, IModelImporter, IModelTransformer, TransformerLoggerCategory } from "../../transformer";
 import {


### PR DESCRIPTION
extend branch workflow tests to include relationship delete

This appears to be broken in main so leaving a draft and merging into the fed guid work where it needs to be redone anyway.