### PR TITLE
propagate new export/processChanges options types through to ChangedInstanceIds.initialize

### DIFF
--- a/packages/test-app/src/Transformer.ts
+++ b/packages/test-app/src/Transformer.ts
@@ -54,7 +54,7 @@ export class Transformer extends IModelTransformer {
     const transformer = new Transformer(sourceDb, targetDb, options);
     await transformer.processSchemas();
     await transformer.saveChanges("processSchemas");
-    await transformer.processChanges({ accessToken, startChangesetId: sourceStartChangesetId });
+    await transformer.processChanges({ accessToken, startChangeset: { id: sourceStartChangesetId } });
     await transformer.saveChanges("processChanges");
     if (options?.deleteUnusedGeometryParts) {
       transformer.deleteUnusedGeometryParts();

--- a/packages/transformer/src/IModelExporter.ts
+++ b/packages/transformer/src/IModelExporter.ts
@@ -294,15 +294,23 @@ export class IModelExporter {
       return;
     }
 
-    const accessToken = typeof accessTokenOrArgs === "object" ? accessTokenOrArgs.accessToken : accessTokenOrArgs;
-    const startChangeset = startChangesetId ? { id: startChangesetId } : this.sourceDb.changeset;
+    const { accessToken, startChangeset }
+      = typeof accessTokenOrArgs === "object"
+        ? accessTokenOrArgs
+        : {
+          accessToken: accessTokenOrArgs,
+          startChangeset: { id: startChangesetId },
+        };
+
     this._sourceDbChanges =
       (typeof accessTokenOrArgs === "object"
         ? accessTokenOrArgs.changedInstanceIds
         : undefined)
       ?? await ChangedInstanceIds.initialize({
         accessToken,
-        startChangeset,
+        startChangeset: startChangeset?.id !== undefined || startChangeset?.index !== undefined
+          ? startChangeset as ChangesetIndexOrId
+          : this.sourceDb.changeset,
         iModel: this.sourceDb,
       });
 

--- a/packages/transformer/src/test/IModelTransformerUtils.ts
+++ b/packages/transformer/src/test/IModelTransformerUtils.ts
@@ -23,7 +23,7 @@ import {
   GeometricElement3dProps, GeometryStreamIterator, IModel, ModelProps, ModelSelectorProps, PhysicalElementProps, Placement3d, QueryRowFormat, SkyBoxImageProps, SkyBoxImageType,
   SpatialViewDefinitionProps, SubCategoryAppearance, SubjectProps, ViewDetails3dProps,
 } from "@itwin/core-common";
-import { IModelExporter, IModelExportHandler, IModelImporter, IModelTransformer } from "../transformer";
+import { ExportChangesOptions, IModelExporter, IModelExportHandler, IModelImporter, IModelTransformer } from "../transformer";
 import { KnownTestLocations } from "./TestUtils/KnownTestLocations";
 
 export class HubWrappers extends TestUtils.HubWrappers {
@@ -1248,9 +1248,10 @@ export class IModelToTextFileExporter extends IModelExportHandler {
     this.writeSeparator();
     await this.exporter.exportAll();
   }
-  public async exportChanges(accessToken: AccessToken, startChangesetId?: string): Promise<void> {
+  public async exportChanges(...args: Parameters<IModelExporter["exportChanges"]>): Promise<void> {
     this._shouldIndent = false;
-    return this.exporter.exportChanges({ accessToken, startChangesetId });
+    // eslint-disable-next-line deprecation/deprecation
+    return this.exporter.exportChanges(...args);
   }
   private writeLine(line: string, indentLevel: number = 0): void {
     if (this._shouldIndent) {

--- a/packages/transformer/src/test/TestUtils/TimelineTestUtil.ts
+++ b/packages/transformer/src/test/TestUtils/TimelineTestUtil.ts
@@ -282,7 +282,7 @@ export async function runTimeline(timeline: Timeline, { iTwinId, accessToken }: 
 
         const syncer = new IModelTransformer(source.db, target.db, { isReverseSynchronization: !isForwardSync });
         const startChangesetId = timelineStates.get(startIndex)?.changesets[syncSource].id;
-        await syncer.processChanges({ accessToken, startChangesetId });
+        await syncer.processChanges({ accessToken, startChangeset: { id: startChangesetId } });
         syncer.dispose();
 
         const stateMsg = `synced changes from ${syncSource} to ${iModelName} at ${i}`;

--- a/packages/transformer/src/test/standalone/IModelTransformerHub.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformerHub.test.ts
@@ -434,7 +434,7 @@ describe("IModelTransformerHub", () => {
       await saveAndPushChanges(replayedDb, "changes from source seed");
       for (const masterDbChangeset of masterDbChangesets) {
         await sourceDb.pullChanges({ accessToken, toIndex: masterDbChangeset.index });
-        await replayTransformer.processChanges({ accessToken, startChangesetId: sourceDb.changeset.id });
+        await replayTransformer.processChanges({ accessToken, startChangeset: sourceDb.changeset });
         await saveAndPushChanges(replayedDb, masterDbChangeset.description ?? "");
       }
       replayTransformer.dispose();
@@ -783,7 +783,7 @@ describe("IModelTransformerHub", () => {
       isReverseSynchronization: true,
     });
     const queryChangeset = sinon.spy(HubMock, "queryChangeset");
-    await syncer.processChanges({ accessToken, startChangesetId: branchAt2Changeset.id });
+    await syncer.processChanges({ accessToken, startChangeset: branchAt2Changeset });
     expect(queryChangeset.alwaysCalledWith({
       accessToken,
       iModelId: branch.id,


### PR DESCRIPTION
- propagate new export/processChanges options types through to `ChangedInstanceIds.initialize`