### PR TITLE
Don't error out on missing .env

### DIFF
--- a/packages/performance-tests/test/setup.ts
+++ b/packages/performance-tests/test/setup.ts
@@ -2,5 +2,5 @@ import dotenv from "dotenv";
 
 const { error } = dotenv.config();
 
-if (error)
-  throw new Error("no env file found");
+if (error && process.env.CI !== "1")
+  throw new Error("no env file found, and not ran as a CI job");

--- a/packages/performance-tests/test/setup.ts
+++ b/packages/performance-tests/test/setup.ts
@@ -2,5 +2,5 @@ import dotenv from "dotenv";
 
 const { error } = dotenv.config();
 
-if (error && process.env.CI !== "1")
+if (error && !process.env.CI)
   throw new Error("no env file found, and not ran as a CI job");


### PR DESCRIPTION
Only error out when both .env file is missing and CI is not set