### PR TITLE
IModelCloneContext.findTargetEntityId fixed relationship id finding

### DIFF
--- a/change/@itwin-imodel-transformer-6c797333-afb8-406b-afe2-be3b8bdb78e6.json
+++ b/change/@itwin-imodel-transformer-6c797333-afb8-406b-afe2-be3b8bdb78e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixed findTargetEntityId when searching for relationship that points to non-existing element in targetIModel",
+  "packageName": "@itwin/imodel-transformer",
+  "email": "51540204+simsta6@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/transformer/src/IModelCloneContext.ts
+++ b/packages/transformer/src/IModelCloneContext.ts
@@ -156,7 +156,7 @@ export class IModelCloneContext extends IModelElementCloneContext {
             targetId: this.findTargetEntityId(relInSource.targetId),
           };
           // return a null
-          if (Id64.isInvalid(relInTarget.sourceId) || Id64.isInvalid(relInTarget.targetId))
+          if (!Id64.isValidId64(relInTarget.sourceId) || !Id64.isValidId64(relInTarget.targetId))
             break;
           const relInTargetId = this.sourceDb.withPreparedStatement(
             `

--- a/packages/transformer/src/IModelCloneContext.ts
+++ b/packages/transformer/src/IModelCloneContext.ts
@@ -156,7 +156,7 @@ export class IModelCloneContext extends IModelElementCloneContext {
             targetId: this.findTargetEntityId(relInSource.targetId),
           };
           // return a null
-          if (!Id64.isValidId64(relInTarget.sourceId) || !Id64.isValidId64(relInTarget.targetId))
+          if (!EntityReferences.isValid(relInTarget.sourceId) || !EntityReferences.isValid(relInTarget.targetId))
             break;
           const relInTargetId = this.sourceDb.withPreparedStatement(
             `


### PR DESCRIPTION
I had to change `Id64.isInvalid` to `!Id64.EntityReferences`, because `Id64.isInvalid` sees "e0" as valid id.
![image](https://github.com/iTwin/imodel-transformer/assets/51540204/6ba9ad9b-9a51-4652-9a2f-f2e58d4ca2a7)

The problem was, that `IModelCloneContext` was trying to find relationship's target or source element that does not exist in the target iModel. So when `findTargetEntityId` returns "e0" for element referenced by relationship it would pass if statement with `Id64.isInvalid` and transformer would crash because `ECSqlStatement.bindId` can't bind invalid64Id.

Now `IModelCloneContext.findTargetEntityId` will return invalid id for target iModel relationship.
