### PR TITLE
Start using BigMap instead of regular Map

### DIFF
--- a/change/@itwin-imodel-transformer-8b752da1-1170-408d-8866-6f0c21f09d02.json
+++ b/change/@itwin-imodel-transformer-8b752da1-1170-408d-8866-6f0c21f09d02.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Start using in BigMap instead of Map to overcome size limits",
+  "packageName": "@itwin/imodel-transformer",
+  "email": "51540204+simsta6@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/transformer/src/BigMap.ts
+++ b/packages/transformer/src/BigMap.ts
@@ -9,7 +9,7 @@ import { Id64String } from "@itwin/core-bentley";
  * This class serves as a temporary solution to address the issue of the V8 JavaScript engine's Map implementation,
  * which is limited to approximately 16.7 million elements. Currently, only valid or invalid Id64 string
  * representations are supported by this Map; any other type will lead to errors. It's worth noting that
- * our future plan is to replace this stopgap with a more robust solution, utilizing a temporary SQLite database.
+ * our future plan is to replace this stopgap with a more robust solution, utilizing a temporary SQLite database (https://github.com/iTwin/imodel-transformer/issues/83).
  */
 export class BigMap<V> extends Map<Id64String, V> {
     private _maps: Record<string, Map<string, V>>;

--- a/packages/transformer/src/BigMap.ts
+++ b/packages/transformer/src/BigMap.ts
@@ -1,0 +1,74 @@
+const MAX_MAP_SIZE = 10_000_000;
+
+export class BigMap<K, V> extends Map<K, V> {
+  private _maps: Map<K, V>[];
+  private _size: number;
+
+  public override get size(): number {
+    return this._size;
+  }
+
+  public constructor() {
+    super();
+    this._maps = [new Map()];
+    this._size = 0;
+  }
+
+  public override clear(): void {
+    this._maps.forEach((m) => m.clear());
+    this._size = 0;
+  }
+
+  public override delete(key: K): boolean {
+    const wasDeleted = this._maps.some((m) => m.delete(key));
+    if (wasDeleted) {
+      this._size--;
+    }
+
+    return wasDeleted;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public override forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void, thisArg?: any): void {
+    this._maps.forEach((m) => {
+      m.forEach(callbackfn, thisArg);
+    });
+  }
+
+  public override get(key: K): V | undefined {
+    for (const map of this._maps) {
+      const value = map.get(key);
+      if (value !== undefined) {
+        return value;
+      }
+    }
+
+    return;
+  }
+
+  public override has(key: K): boolean {
+    return this._maps.some((m) => m.has(key));
+  }
+
+  public override set(key: K, value: V): this {
+    // duplicate key
+    for (const map of this._maps) {
+      if (map.has(key)) {
+        map.set(key, value);
+      }
+    }
+
+    const lastMap = this._maps[this._maps.length - 1];
+    if (lastMap.size < MAX_MAP_SIZE) { // last map has free space
+      lastMap.set(key, value);
+    } else { // item will be put into new map
+      const newMap = new Map();
+      newMap.set(key, value);
+      this._maps.push(newMap);
+    }
+
+    this._size++;
+
+    return this;
+  }
+}

--- a/packages/transformer/src/BigMap.ts
+++ b/packages/transformer/src/BigMap.ts
@@ -2,7 +2,9 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-
+/** @packageDocumentation
+ * @module BigMap
+ */
 import { Id64String } from "@itwin/core-bentley";
 
 /**

--- a/packages/transformer/src/BigMap.ts
+++ b/packages/transformer/src/BigMap.ts
@@ -3,7 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 /** @packageDocumentation
- * @module BigMap
+ * @module Utils
  */
 import { Id64String } from "@itwin/core-bentley";
 
@@ -12,6 +12,7 @@ import { Id64String } from "@itwin/core-bentley";
  * which is limited to approximately 16.7 million elements. Currently, only Id64 string representations are
  * supported by this Map; any other type will lead to errors. It's worth noting that our future plan is to
  * replace this stopgap with a more robust solution, utilizing a temporary SQLite database (https://github.com/iTwin/imodel-transformer/issues/83).
+ * @internal
  */
 export class BigMap<V> extends Map<Id64String, V> {
     private _maps: Record<string, Map<string, V>>;

--- a/packages/transformer/src/BigMap.ts
+++ b/packages/transformer/src/BigMap.ts
@@ -55,6 +55,7 @@ export class BigMap<K, V> extends Map<K, V> {
     for (const map of this._maps) {
       if (map.has(key)) {
         map.set(key, value);
+        return this;
       }
     }
 

--- a/packages/transformer/src/BigMap.ts
+++ b/packages/transformer/src/BigMap.ts
@@ -5,6 +5,12 @@
 
 import { Id64String } from "@itwin/core-bentley";
 
+/**
+ * This class serves as a temporary solution to address the issue of the V8 JavaScript engine's Map implementation,
+ * which is limited to approximately 16.7 million elements. Currently, only valid or invalid Id64 string
+ * representations are supported by this Map; any other type will lead to errors. It's worth noting that
+ * our future plan is to replace this stopgap with a more robust solution, utilizing a temporary SQLite database.
+ */
 export class BigMap<V> extends Map<Id64String, V> {
     private _maps: Record<string, Map<string, V>>;
     private _size: number;
@@ -67,7 +73,7 @@ export class BigMap<V> extends Map<Id64String, V> {
     public override set(key: Id64String, value: V): this {
       const mapForKey = this._maps[key[key.length - 1]];
       if (mapForKey === undefined)
-        throw Error(`Tried to set ${key} with ${value}`);
+        throw Error(`Tried to set ${key}, but that key has no submap`);
       const beforeSize = mapForKey.size;
       mapForKey.set(key, value);
       const afterSize = mapForKey.size;

--- a/packages/transformer/src/BigMap.ts
+++ b/packages/transformer/src/BigMap.ts
@@ -7,9 +7,9 @@ import { Id64String } from "@itwin/core-bentley";
 
 /**
  * This class serves as a temporary solution to address the issue of the V8 JavaScript engine's Map implementation,
- * which is limited to approximately 16.7 million elements. Currently, only valid or invalid Id64 string
- * representations are supported by this Map; any other type will lead to errors. It's worth noting that
- * our future plan is to replace this stopgap with a more robust solution, utilizing a temporary SQLite database (https://github.com/iTwin/imodel-transformer/issues/83).
+ * which is limited to approximately 16.7 million elements. Currently, only Id64 string representations are
+ * supported by this Map; any other type will lead to errors. It's worth noting that our future plan is to
+ * replace this stopgap with a more robust solution, utilizing a temporary SQLite database (https://github.com/iTwin/imodel-transformer/issues/83).
  */
 export class BigMap<V> extends Map<Id64String, V> {
     private _maps: Record<string, Map<string, V>>;

--- a/packages/transformer/src/EntityMap.ts
+++ b/packages/transformer/src/EntityMap.ts
@@ -7,13 +7,14 @@
  */
 import { EntityReference } from "@itwin/core-common";
 import { ConcreteEntity, EntityReferences } from "@itwin/core-backend";
+import { BigMap } from "./BigMap";
 
 /** @internal */
 export type EntityKey = EntityReference;
 
 /** @internal */
 export class EntityMap<V> {
-  private _map = new Map<EntityKey, V>();
+  private _map = new BigMap<EntityKey, V>();
 
   public static makeKey(entity: ConcreteEntity): EntityKey {
     return EntityReferences.from(entity);

--- a/packages/transformer/src/PendingReferenceMap.ts
+++ b/packages/transformer/src/PendingReferenceMap.ts
@@ -9,6 +9,7 @@
 import { EntityReference } from "@itwin/core-common";
 import { ConcreteEntity, EntityReferences } from "@itwin/core-backend";
 import { EntityMap } from "./EntityMap";
+import { BigMap } from "./BigMap";
 
 /**
  * A reference relationships from an element, "referencer", to an element or its submodel, "referenced"
@@ -43,7 +44,7 @@ export namespace PendingReference {
  * as well as getting a list of referencers from a referencee (called referenced)
  */
 export class PendingReferenceMap<T> {
-  private _map = new Map<string, T>();
+  private _map = new BigMap<string, T>();
   private _referencedToReferencers = new EntityMap<Set<EntityReference>>();
 
   public getReferencers(referenced: ConcreteEntity): Set<EntityReference> {

--- a/packages/transformer/src/transformer.ts
+++ b/packages/transformer/src/transformer.ts
@@ -84,3 +84,8 @@ if (process.env[noStrictDepCheckEnvVar] !== "1" && !semver.satisfies(iTwinCoreBa
  * @docs-group-description Logging
  * Logger categories used by this package.
  */
+/**
+ * @docs-group-description BigMap
+ * This class provides an interim solution to overcome V8 JavaScript engine's Map size limitation of about 16.7 million elements.
+ * It currently only supports Id64 string representations. We aim to eventually replace this patch with a temporary SQLite database.
+ */

--- a/packages/transformer/src/transformer.ts
+++ b/packages/transformer/src/transformer.ts
@@ -84,8 +84,3 @@ if (process.env[noStrictDepCheckEnvVar] !== "1" && !semver.satisfies(iTwinCoreBa
  * @docs-group-description Logging
  * Logger categories used by this package.
  */
-/**
- * @docs-group-description BigMap
- * This class provides an interim solution to overcome V8 JavaScript engine's Map size limitation of about 16.7 million elements.
- * It currently only supports Id64 string representations. We aim to eventually replace this patch with a temporary SQLite database.
- */


### PR DESCRIPTION
When transforming iModels with huge amounts of Element Aspects process can crash.

BigMap implementation will decrease performance by little bit.

To decrease memory usage, we can use https://www.npmjs.com/package/lmdb