### PR TITLE
Fix element provenance direction in reverse synchronization workflow

### DIFF
--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -644,19 +644,8 @@ export class IModelTransformer extends IModelExportHandler {
       throw new IModelError(IModelStatus.BadSchema, "The BisCore schema version of the target database is too old");
     }
 
-    const runFnInProvDirection = (sourceId: Id64String, targetId: Id64String) =>
-      this._options.isReverseSynchronization ? fn(sourceId, targetId) : fn(targetId, sourceId);
-
     // query for provenanceDb
-    const provenanceContainerQuery = `
-      SELECT e.ECInstanceId, FederationGuid
-      FROM bis.Element e
-      WHERE e.ECInstanceId NOT IN (0x1, 0xe, 0x10) -- special static elements
-      ORDER BY FederationGuid
-    `;
-
-    // query for nonProvenanceDb, the source to which the provenance is referring
-    const provenanceSourceQuery = `
+    const elementIdByFedGuidQuery = `
       SELECT e.ECInstanceId, FederationGuid
       FROM bis.Element e
       WHERE e.ECInstanceId NOT IN (0x1, 0xe, 0x10) -- special static elements
@@ -667,36 +656,36 @@ export class IModelTransformer extends IModelExportHandler {
     // NOTE: if we exposed the native attach database support,
     // we could get the intersection of fed guids in one query, not sure if it would be faster
     // OR we could do a raw sqlite query...
-    this.provenanceSourceDb.withStatement(provenanceSourceQuery, (sourceStmt) => this.provenanceDb.withStatement(provenanceContainerQuery, (containerStmt) => {
+    this.sourceDb.withStatement(elementIdByFedGuidQuery, (sourceStmt) => this.targetDb.withStatement(elementIdByFedGuidQuery, (targetStmt) => {
       if (sourceStmt.step() !== DbResult.BE_SQLITE_ROW)
         return;
       let sourceRow = sourceStmt.getRow() as { federationGuid?: GuidString, id: Id64String };
-      if (containerStmt.step() !== DbResult.BE_SQLITE_ROW)
+      if (targetStmt.step() !== DbResult.BE_SQLITE_ROW)
         return;
-      let containerRow = containerStmt.getRow() as { federationGuid?: GuidString, id: Id64String };
+      let targetRow = targetStmt.getRow() as { federationGuid?: GuidString, id: Id64String };
 
       // NOTE: these comparisons rely upon the lowercase of the guid,
       // and the fact that '0' < '9' < a' < 'f' in ascii/utf8
       while (true) {
-        const currSourceRow = sourceRow, currContainerRow = containerRow;
+        const currSourceRow = sourceRow, currTargetRow = targetRow;
         if (currSourceRow.federationGuid !== undefined
-          && currContainerRow.federationGuid !== undefined
-          && currSourceRow.federationGuid === currContainerRow.federationGuid
+          && currTargetRow.federationGuid !== undefined
+          && currSourceRow.federationGuid === currTargetRow.federationGuid
         ) {
-          // not this is already in provenance direction, no need to use runFnInProvDirection
-          fn(sourceRow.id, containerRow.id);
+          // data flow direction is always sourceDb -> targetDb and it does not depend on where the explicit element provenance is stored
+          fn(sourceRow.id, targetRow.id);
         }
-        if (currContainerRow.federationGuid === undefined
+        if (currTargetRow.federationGuid === undefined
           || (currSourceRow.federationGuid !== undefined
-            && currSourceRow.federationGuid >= currContainerRow.federationGuid)
+            && currSourceRow.federationGuid >= currTargetRow.federationGuid)
         ) {
-          if (containerStmt.step() !== DbResult.BE_SQLITE_ROW)
+          if (targetStmt.step() !== DbResult.BE_SQLITE_ROW)
             return;
-          containerRow = containerStmt.getRow();
+          targetRow = targetStmt.getRow();
         }
         if (currSourceRow.federationGuid === undefined
-          || (currContainerRow.federationGuid !== undefined
-            && currSourceRow.federationGuid <= currContainerRow.federationGuid)
+          || (currTargetRow.federationGuid !== undefined
+            && currSourceRow.federationGuid <= currTargetRow.federationGuid)
         ) {
           if (sourceStmt.step() !== DbResult.BE_SQLITE_ROW)
             return;
@@ -717,13 +706,15 @@ export class IModelTransformer extends IModelExportHandler {
     // victims of the old provenance method that have both fedguids and an inserted aspect.
     // But this is a private function with one known caller where that doesn't matter
     this.provenanceDb.withPreparedStatement(provenanceAspectsQuery, (stmt): void => {
+      const runFnInDataFlowDirection = (sourceId: Id64String, targetId: Id64String) =>
+        this._options.isReverseSynchronization ? fn(sourceId, targetId) : fn(targetId, sourceId);
       stmt.bindId("scopeId", this.targetScopeElementId);
       stmt.bindString("kind", ExternalSourceAspect.Kind.Element);
       while (DbResult.BE_SQLITE_ROW === stmt.step()) {
         // ExternalSourceAspect.Identifier is of type string
         const aspectIdentifier: Id64String = stmt.getValue(0).getString();
         const elementId: Id64String = stmt.getValue(1).getId();
-        runFnInProvDirection(elementId, aspectIdentifier);
+        runFnInDataFlowDirection(elementId, aspectIdentifier);
       }
     });
   }

--- a/packages/transformer/src/test/standalone/IModelTransformerHub.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformerHub.test.ts
@@ -1188,54 +1188,54 @@ describe("IModelTransformerHub", () => {
     assert.isTrue(Guid.isGuid(targetIModelId));
 
     try {
-        const sourceDb = await HubWrappers.downloadAndOpenBriefcase({ accessToken, iTwinId, iModelId: sourceIModelId });
-        const targetDb = await HubWrappers.downloadAndOpenBriefcase({ accessToken, iTwinId, iModelId: targetIModelId });
+      const sourceDb = await HubWrappers.downloadAndOpenBriefcase({ accessToken, iTwinId, iModelId: sourceIModelId });
+      const targetDb = await HubWrappers.downloadAndOpenBriefcase({ accessToken, iTwinId, iModelId: targetIModelId });
 
-        const categoryId = SpatialCategory.insert(sourceDb, IModel.dictionaryId, "C1", {});
-        const modelId = PhysicalModel.insert(sourceDb, IModel.rootSubjectId, "PM1");
-        const physicalElement: PhysicalElementProps = {
-            classFullName: PhysicalObject.classFullName,
-            model: modelId,
-            category: categoryId,
-            code: Code.createEmpty(),
-            userLabel: "Element1"
-        };
-        const originalElementId = sourceDb.elements.insertElement(physicalElement);
+      const categoryId = SpatialCategory.insert(sourceDb, IModel.dictionaryId, "C1", {});
+      const modelId = PhysicalModel.insert(sourceDb, IModel.rootSubjectId, "PM1");
+      const physicalElement: PhysicalElementProps = {
+        classFullName: PhysicalObject.classFullName,
+        model: modelId,
+        category: categoryId,
+        code: Code.createEmpty(),
+        userLabel: "Element1"
+      };
+      const originalElementId = sourceDb.elements.insertElement(physicalElement);
 
-        sourceDb.saveChanges();
-        await sourceDb.pushChanges({ description: "insert physical element" });
+      sourceDb.saveChanges();
+      await sourceDb.pushChanges({ description: "insert physical element" });
 
-        let transformer = new IModelTransformer(sourceDb, targetDb);
-        await transformer.processAll();
-        const forkedElementId = transformer.context.findTargetElementId(originalElementId);
-        expect(forkedElementId).not.to.be.undefined;
-        transformer.dispose();
-        targetDb.saveChanges();
-        await targetDb.pushChanges({ description: "initial transformation" });
+      let transformer = new IModelTransformer(sourceDb, targetDb);
+      await transformer.processAll();
+      const forkedElementId = transformer.context.findTargetElementId(originalElementId);
+      expect(forkedElementId).not.to.be.undefined;
+      transformer.dispose();
+      targetDb.saveChanges();
+      await targetDb.pushChanges({ description: "initial transformation" });
 
-        const forkedElement = targetDb.elements.getElement(forkedElementId);
-        forkedElement.userLabel = "Element1_updated";
-        forkedElement.update();
-        targetDb.saveChanges();
-        await targetDb.pushChanges({ description: "update forked element's userLabel" });
+      const forkedElement = targetDb.elements.getElement(forkedElementId);
+      forkedElement.userLabel = "Element1_updated";
+      forkedElement.update();
+      targetDb.saveChanges();
+      await targetDb.pushChanges({ description: "update forked element's userLabel" });
 
-        transformer = new IModelTransformer(targetDb, sourceDb, {isReverseSynchronization: true});
-        await transformer.processChanges({startChangeset: {id: targetDb.changeset.id}});
-        sourceDb.saveChanges();
-        await sourceDb.pushChanges({ description: "change processing transformation" });
+      transformer = new IModelTransformer(targetDb, sourceDb, {isReverseSynchronization: true});
+      await transformer.processChanges({startChangeset: targetDb.changeset});
+      sourceDb.saveChanges();
+      await sourceDb.pushChanges({ description: "change processing transformation" });
 
-        const masterElement = sourceDb.elements.getElement(originalElementId);
-        expect(masterElement).to.not.be.undefined;
-        expect(masterElement.userLabel).to.be.equal("Element1_updated");
+      const masterElement = sourceDb.elements.getElement(originalElementId);
+      expect(masterElement).to.not.be.undefined;
+      expect(masterElement.userLabel).to.be.equal("Element1_updated");
     } finally {
-        try {
+      try {
         // delete iModel briefcases
         await IModelHost.hubAccess.deleteIModel({ iTwinId, iModelId: sourceIModelId });
         await IModelHost.hubAccess.deleteIModel({ iTwinId, iModelId: targetIModelId });
-        } catch (err) {
+      } catch (err) {
         // eslint-disable-next-line no-console
         console.log("can't destroy", err);
-        }
+      }
     }
 });
 

--- a/packages/transformer/src/test/standalone/IModelTransformerHub.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformerHub.test.ts
@@ -1179,6 +1179,66 @@ describe("IModelTransformerHub", () => {
     sinon.restore();
   });
 
+  it("should reverse synchronize forked iModel when an element was updated", async() => {
+    const sourceIModelName: string = IModelTransformerTestUtils.generateUniqueName("Master");
+    const sourceIModelId = await HubWrappers.recreateIModel({ accessToken, iTwinId, iModelName: sourceIModelName, noLocks: true });
+    assert.isTrue(Guid.isGuid(sourceIModelId));
+    const targetIModelName: string = IModelTransformerTestUtils.generateUniqueName("Fork");
+    const targetIModelId = await HubWrappers.recreateIModel({ accessToken, iTwinId, iModelName: targetIModelName, noLocks: true });
+    assert.isTrue(Guid.isGuid(targetIModelId));
+
+    try {
+        const sourceDb = await HubWrappers.downloadAndOpenBriefcase({ accessToken, iTwinId, iModelId: sourceIModelId });
+        const targetDb = await HubWrappers.downloadAndOpenBriefcase({ accessToken, iTwinId, iModelId: targetIModelId });
+
+        const categoryId = SpatialCategory.insert(sourceDb, IModel.dictionaryId, "C1", {});
+        const modelId = PhysicalModel.insert(sourceDb, IModel.rootSubjectId, "PM1");
+        const physicalElement: PhysicalElementProps = {
+            classFullName: PhysicalObject.classFullName,
+            model: modelId,
+            category: categoryId,
+            code: Code.createEmpty(),
+            userLabel: "Element1"
+        };
+        const originalElementId = sourceDb.elements.insertElement(physicalElement);
+
+        sourceDb.saveChanges();
+        await sourceDb.pushChanges({ description: "insert physical element" });
+
+        let transformer = new IModelTransformer(sourceDb, targetDb);
+        await transformer.processAll();
+        const forkedElementId = transformer.context.findTargetElementId(originalElementId);
+        expect(forkedElementId).not.to.be.undefined;
+        transformer.dispose();
+        targetDb.saveChanges();
+        await targetDb.pushChanges({ description: "initial transformation" });
+
+        const forkedElement = targetDb.elements.getElement(forkedElementId);
+        forkedElement.userLabel = "Element1_updated";
+        forkedElement.update();
+        targetDb.saveChanges();
+        await targetDb.pushChanges({ description: "update forked element's userLabel" });
+
+        transformer = new IModelTransformer(targetDb, sourceDb, {isReverseSynchronization: true});
+        await transformer.processChanges({startChangeset: {id: targetDb.changeset.id}});
+        sourceDb.saveChanges();
+        await sourceDb.pushChanges({ description: "change processing transformation" });
+
+        const masterElement = sourceDb.elements.getElement(originalElementId);
+        expect(masterElement).to.not.be.undefined;
+        expect(masterElement.userLabel).to.be.equal("Element1_updated");
+    } finally {
+        try {
+        // delete iModel briefcases
+        await IModelHost.hubAccess.deleteIModel({ iTwinId, iModelId: sourceIModelId });
+        await IModelHost.hubAccess.deleteIModel({ iTwinId, iModelId: targetIModelId });
+        } catch (err) {
+        // eslint-disable-next-line no-console
+        console.log("can't destroy", err);
+        }
+    }
+});
+
   // will fix in separate PR, tracked here: https://github.com/iTwin/imodel-transformer/issues/27
   it.skip("should delete definition elements when processing changes", async () => {
     let spatialViewDef: SpatialViewDefinition;


### PR DESCRIPTION
`forEachTrackedElement` method iterates through related (tracked) elements in 2 imodels and invokes a callback on each pair.
There are 2 scenarios for iterating through tracked elements during transformer initialization.

1. Provenance is stored in target: Source ----> Target (prov)
2. Provenance is stored in source: Source (prov) ----> Target

These 2 scenarios only matter when the provenance is tracked by `ExternalSourceAspects` since depending on the provenance location the `element.id` and `identifier` fields will be switched.

When provenance is tracked by federation guids we don't care where the provenance is, because the callback should always be invoked in the data flow direction and not the provenance direction.
Methods that depend on the remap table (e.g. `findTargetElementId`) will only ever by called with the element id in the sourceDb to get element id in targetDb.