### PR TITLE
[fedGuid] Handle cases when element was recreated instead of updated

### DIFF
--- a/packages/transformer/src/IModelExporter.ts
+++ b/packages/transformer/src/IModelExporter.ts
@@ -104,6 +104,12 @@ export abstract class IModelExportHandler {
    */
   public async preExportElement(_element: Element): Promise<void> {}
 
+  /**
+   * Do any asynchronous actions before element deletions are handled.
+   * @internal
+   */
+  public async preDeleteElements(): Promise<void> {}
+
   /** Called when an element should be deleted. */
   public onDeleteElement(_elementId: Id64String): void { }
 
@@ -324,6 +330,7 @@ export class IModelExporter {
 
     // handle deletes
     if (this.visitElements) {
+      await this.handler.preDeleteElements();
       // must delete models first since they have a constraint on the submodeling element which may also be deleted
       for (const modelId of this._sourceDbChanges.model.deleteIds) {
         this.handler.onDeleteModel(modelId);

--- a/packages/transformer/src/IModelExporter.ts
+++ b/packages/transformer/src/IModelExporter.ts
@@ -773,8 +773,10 @@ export class IModelExporter {
     }
   }
 
+ // An unnecessary delete will be triggered if a source element was deleted and then inserted with the same federation guid.
+ // In such case an element update will have already been triggered and a delete operation will not be necessary.
   private handleEntityRecreations(): void {
-    const alreadyInsertedElementIds = new Set<Id64String> ();
+    const alreadyInsertedElementIds = new Set<Id64String>();
     this.sourceDbChanges?.element.insertIds.forEach((insertedSourceElementId) => {
       const targetElementId = this.handler.findTargetElementId(insertedSourceElementId);
       if (Id64.isValid(targetElementId))
@@ -788,10 +790,10 @@ export class IModelExporter {
     });
 
     this.sourceDbChanges?.model.deleteIds.forEach((deletedModelId) => {
-        const targetModelToDelete = this.handler.findTargetElementId(deletedModelId);
-        if (alreadyInsertedElementIds.has(targetModelToDelete))
-          this.sourceDbChanges?.model.deleteIds.delete(deletedModelId);
-      });
+      const targetModelToDelete = this.handler.findTargetElementId(deletedModelId);
+      if (alreadyInsertedElementIds.has(targetModelToDelete))
+        this.sourceDbChanges?.model.deleteIds.delete(deletedModelId);
+    });
   }
 
   /** Tracks incremental progress */

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -2070,7 +2070,7 @@ export class IModelTransformer extends IModelExportHandler {
     await this._tryInitChangesetData(args);
 
     const exporterInitOptions: ExporterInitOptions = {};
-    if(this._isSynchronization)
+    if (this._isSynchronization)
       exporterInitOptions.exportChangesOptions = this.getExportChangesOptions(args?.accessToken, args?.startChangeset?.id);
     await this.exporter.initialize(exporterInitOptions);
     // Exporter must be initialized prior to `initFromExternalSourceAspects` in order to handle entity recreations.

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -9,7 +9,7 @@ import * as path from "path";
 import * as Semver from "semver";
 import * as nodeAssert from "assert";
 import {
-  AccessToken, assert, CompressedId64Set, DbResult, Guid, GuidString, Id64, Id64Array, Id64Set, Id64String, IModelStatus, Logger, MarkRequired,
+  AccessToken, assert, CompressedId64Set, DbResult, Guid, GuidString, Id64, Id64Array, Id64String, IModelStatus, Logger, MarkRequired,
   OpenMode, YieldManager,
 } from "@itwin/core-bentley";
 import * as ECSchemaMetaData from "@itwin/ecschema-metadata";
@@ -1467,15 +1467,15 @@ export class IModelTransformer extends IModelExportHandler {
   /** Look up a target ElementId from the source ElementId.
    * @returns the target ElementId or [Id64.invalid]($bentley) if a mapping not found.
    */
-  public override findTargetElementId(sourceElementId: Id64String): Id64String { return this.context.findTargetElementId(sourceElementId); }
+  public override findTargetElementId(sourceElementId: Id64String): Id64String {
+    return this.context.findTargetElementId(sourceElementId);
+  }
 
   /** Override of [IModelExportHandler.onDeleteElement]($transformer) that is called when [IModelExporter]($transformer) detects that an Element has been deleted from the source iModel.
    * This override propagates the delete to the target iModel via [IModelImporter.deleteElement]($transformer).
    */
   public override onDeleteElement(sourceElementId: Id64String): void {
     const targetElementId: Id64String = this.context.findTargetElementId(sourceElementId);
-    // An unnecessary delete will be triggered if a source element was deleted and then inserted with the same federation guid.
-    // In such case an element update will have already been triggered and a delete operation will not be necessary.
     if (Id64.isValidId64(targetElementId)) {
       this.importer.deleteElement(targetElementId);
     }
@@ -1500,8 +1500,6 @@ export class IModelTransformer extends IModelExportHandler {
     // - If only the model is deleted, [[initFromExternalSourceAspects]] will have already remapped the underlying element since it still exists.
     // - If both were deleted, [[remapDeletedSourceEntities]] will find and remap the deleted element making this operation valid
     const targetModelId: Id64String = this.context.findTargetElementId(sourceModelId);
-    // An unnecessary delete will be triggered if a source element was deleted and then inserted with the same federation guid.
-    // In such case an element update will have already been triggered and a delete operation will not be necessary.
     if (Id64.isValidId64(targetModelId)) {
       this.importer.deleteModel(targetModelId);
     }

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -943,7 +943,7 @@ export class IModelTransformer extends IModelExportHandler {
             if (alreadyImportedElementInserts.has(targetId)) {
               this.exporter.sourceDbChanges?.element.deleteIds.delete(instId);
             }
-            if(alreadyImportedModelInserts.has(targetId)) {
+            if (alreadyImportedModelInserts.has(targetId)) {
               this.exporter.sourceDbChanges?.model.deleteIds.delete(instId);
             }
 

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -940,7 +940,7 @@ export class IModelTransformer extends IModelExportHandler {
             this.context.remapElement(instId, targetId);
             // If an entity insert and an entity delete both point to the same entity in target iModel, that means that entity was recreated.
             // In such case an entity update will be triggered and we no longer need to delete the entity.
-            if(alreadyImportedElementInserts.has(targetId)) {
+            if (alreadyImportedElementInserts.has(targetId)) {
               this.exporter.sourceDbChanges?.element.deleteIds.delete(instId);
             }
             if(alreadyImportedModelInserts.has(targetId)) {

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -9,7 +9,7 @@ import * as path from "path";
 import * as Semver from "semver";
 import * as nodeAssert from "assert";
 import {
-  AccessToken, assert, CompressedId64Set, DbResult, Guid, GuidString, Id64, Id64Array, Id64String, IModelStatus, Logger, MarkRequired,
+  AccessToken, assert, CompressedId64Set, DbResult, Guid, GuidString, Id64, Id64Array, Id64Set, Id64String, IModelStatus, Logger, MarkRequired,
   OpenMode, YieldManager,
 } from "@itwin/core-bentley";
 import * as ECSchemaMetaData from "@itwin/ecschema-metadata";
@@ -306,6 +306,11 @@ export class IModelTransformer extends IModelExportHandler {
 
   /** a set of elements for which source provenance will be explicitly tracked by ExternalSourceAspects */
   protected _elementsWithExplicitlyTrackedProvenance = new Set<Id64String>();
+
+  /** a set of target element ids that were newly inserted during change processing workflow.
+   * This set will be initialized only after processing element inserts.
+   */
+  private _insertedTargetElementIds: Id64Set = new Set<Id64String> ();
 
   /** map of partially committed entities to their partial commit progress */
   protected _partiallyCommittedEntities = new EntityMap<PartiallyCommittedEntity>();
@@ -1464,12 +1469,21 @@ export class IModelTransformer extends IModelExportHandler {
     }
   }
 
+  /**
+   * Remember all target element ids that were newly inserted during current change processing.
+   */
+  public override async preDeleteElements(): Promise<void> {
+    this.exporter.sourceDbChanges?.element.insertIds.forEach((insertedSourceElementId) => this._insertedTargetElementIds.add(this.context.findTargetElementId(insertedSourceElementId)));
+  }
+
   /** Override of [IModelExportHandler.onDeleteElement]($transformer) that is called when [IModelExporter]($transformer) detects that an Element has been deleted from the source iModel.
    * This override propagates the delete to the target iModel via [IModelImporter.deleteElement]($transformer).
    */
   public override onDeleteElement(sourceElementId: Id64String): void {
     const targetElementId: Id64String = this.context.findTargetElementId(sourceElementId);
-    if (Id64.isValidId64(targetElementId)) {
+    // An unnecessary delete will be triggered if a source element was deleted and then inserted with the same federation guid.
+    // In such case an element update will have already been triggered and a delete operation will not be necessary.
+    if (Id64.isValidId64(targetElementId) && !this._insertedTargetElementIds.has(targetElementId)) {
       this.importer.deleteElement(targetElementId);
     }
   }
@@ -1493,7 +1507,9 @@ export class IModelTransformer extends IModelExportHandler {
     // - If only the model is deleted, [[initFromExternalSourceAspects]] will have already remapped the underlying element since it still exists.
     // - If both were deleted, [[remapDeletedSourceEntities]] will find and remap the deleted element making this operation valid
     const targetModelId: Id64String = this.context.findTargetElementId(sourceModelId);
-    if (Id64.isValidId64(targetModelId)) {
+    // An unnecessary delete will be triggered if a source element was deleted and then inserted with the same federation guid.
+    // In such case an element update will have already been triggered and a delete operation will not be necessary.
+    if (Id64.isValidId64(targetModelId) && !this._insertedTargetElementIds.has(targetModelId)) {
       this.importer.deleteModel(targetModelId);
     }
   }

--- a/packages/transformer/src/test/TestUtils/IModelTestUtils.ts
+++ b/packages/transformer/src/test/TestUtils/IModelTestUtils.ts
@@ -693,8 +693,8 @@ export class IModelTestUtils {
     });
   }
 
-  public static count(iModelDb: IModelDb, classFullName: string): number {
-    return iModelDb.withPreparedStatement(`SELECT COUNT(*) FROM ${classFullName}`, (statement: ECSqlStatement): number => {
+  public static count(iModelDb: IModelDb, classFullName: string, whereClause?: string): number {
+    return iModelDb.withPreparedStatement(`SELECT COUNT(*) FROM ${classFullName}${whereClause ? ` WHERE ${whereClause}` : ""}`, (statement: ECSqlStatement): number => {
       return DbResult.BE_SQLITE_ROW === statement.step() ? statement.getValue(0).getInteger() : 0;
     });
   }

--- a/packages/transformer/src/test/standalone/IModelTransformerHub.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformerHub.test.ts
@@ -1456,6 +1456,84 @@ describe("IModelTransformerHub", () => {
     }
   });
 
+  it("should delete model when its partition was recreated, but model was left deleted", async () => {
+    const sourceIModelName: string = IModelTransformerTestUtils.generateUniqueName("Source");
+    const sourceIModelId = await HubWrappers.recreateIModel({ accessToken, iTwinId, iModelName: sourceIModelName, noLocks: true });
+    assert.isTrue(Guid.isGuid(sourceIModelId));
+    const targetIModelName: string = IModelTransformerTestUtils.generateUniqueName("Fork");
+    const targetIModelId = await HubWrappers.recreateIModel({ accessToken, iTwinId, iModelName: targetIModelName, noLocks: true });
+    assert.isTrue(Guid.isGuid(targetIModelId));
+
+    try {
+    const sourceDb = await HubWrappers.downloadAndOpenBriefcase({ accessToken, iTwinId, iModelId: sourceIModelId });
+    const targetDb = await HubWrappers.downloadAndOpenBriefcase({ accessToken, iTwinId, iModelId: targetIModelId });
+
+    const constPartitionFedGuid = Guid.createValue();
+    const originalPartitionId = sourceDb.elements.insertElement({
+      model: IModel.repositoryModelId,
+      code: PhysicalPartition.createCode(sourceDb, IModel.rootSubjectId, "original partition"),
+      classFullName: PhysicalPartition.classFullName,
+      federationGuid: constPartitionFedGuid,
+      parent: new SubjectOwnsPartitionElements(IModel.rootSubjectId),
+    });
+    const modelId = sourceDb.models.insertModel({
+      classFullName: PhysicalModel.classFullName,
+      modeledElement: {id: originalPartitionId},
+      isPrivate: true,
+    });
+
+    sourceDb.saveChanges();
+    await sourceDb.pushChanges({ description: "inserted elements & models" });
+
+    let transformer = new IModelTransformer(sourceDb, targetDb);
+    await transformer.processAll();
+    transformer.dispose();
+    targetDb.saveChanges();
+    await targetDb.pushChanges({ description: "initial transformation" });
+
+    const originalTargetPartition = targetDb.elements.getElement<PhysicalPartition>({federationGuid: constPartitionFedGuid}, PhysicalPartition);
+    expect(originalTargetPartition.code.value).to.be.equal("original partition");
+    const originalTargetModel = targetDb.models.getModel<PhysicalModel>(originalTargetPartition.id, PhysicalModel);
+    expect(originalTargetModel.isPrivate).to.be.true;
+
+    sourceDb.models.deleteModel(modelId);
+    sourceDb.elements.deleteElement(originalPartitionId);
+    sourceDb.elements.insertElement({
+      model: IModel.repositoryModelId,
+      code: PhysicalPartition.createCode(sourceDb, IModel.rootSubjectId, "recreated partition"),
+      classFullName: PhysicalPartition.classFullName,
+      federationGuid: constPartitionFedGuid,
+      parent: new SubjectOwnsPartitionElements(IModel.rootSubjectId),
+    });
+
+    sourceDb.saveChanges();
+    await sourceDb.pushChanges({ description: "recreated elements & models" });
+
+    transformer = new IModelTransformer(sourceDb, targetDb);
+    await transformer.processChanges({startChangeset: sourceDb.changeset});
+    targetDb.saveChanges();
+    await targetDb.pushChanges({ description: "change processing transformation" });
+
+    const targetPartition = targetDb.elements.getElement<PhysicalPartition>({federationGuid: constPartitionFedGuid}, PhysicalPartition);
+    expect(targetPartition.code.value).to.be.equal("recreated partition");
+
+    expect(count(sourceDb, PhysicalPartition.classFullName)).to.equal(1);
+    expect(count(targetDb, PhysicalPartition.classFullName)).to.equal(1);
+    expect(count(sourceDb, PhysicalModel.classFullName)).to.equal(0);
+    expect(count(targetDb, PhysicalModel.classFullName)).to.equal(0);
+
+    } finally {
+      try {
+        // delete iModel briefcases
+        await IModelHost.hubAccess.deleteIModel({ iTwinId, iModelId: sourceIModelId });
+        await IModelHost.hubAccess.deleteIModel({ iTwinId, iModelId: targetIModelId });
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.log("can't destroy", err);
+      }
+    }
+  });
+
   // will fix in separate PR, tracked here: https://github.com/iTwin/imodel-transformer/issues/27
   it.skip("should delete definition elements when processing changes", async () => {
     let spatialViewDef: SpatialViewDefinition;

--- a/packages/transformer/src/test/standalone/IModelTransformerHub.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformerHub.test.ts
@@ -14,7 +14,7 @@ import {
 
 import * as TestUtils from "../TestUtils";
 import { AccessToken, DbResult, Guid, GuidString, Id64, Id64Array, Id64String, Logger, LogLevel } from "@itwin/core-bentley";
-import { Code, ColorDef, ElementProps, ExternalSourceAspectProps, IModel, IModelVersion, InformationPartitionElementProps, PhysicalElementProps, Placement3d, SubCategoryAppearance } from "@itwin/core-common";
+import { Code, ColorDef, ElementProps, ExternalSourceAspectProps, IModel, IModelVersion, PhysicalElementProps, Placement3d, SubCategoryAppearance } from "@itwin/core-common";
 import { Point3d, YawPitchRollAngles } from "@itwin/core-geometry";
 import { IModelExporter, IModelImporter, IModelTransformer, TransformerLoggerCategory } from "../../transformer";
 import {


### PR DESCRIPTION
When an element gets updated by recreating it, the transformer sees 2 changes: 1 delete and 1 insert.
Since provenance is tracked by fed guids the insert will not happen, and an element update will be triggered instead. When this happens we no longer need to invoke the delete operation on the updated element.
We achieve this by keeping track of newly inserted elements in the target iModel and ignoring deletes on these elements.