### PR TITLE
Added isFirstSynchronization to options

### DIFF
--- a/change/@itwin-imodel-transformer-5c762aed-a0d1-466c-9388-7d9a060b3c4a.json
+++ b/change/@itwin-imodel-transformer-5c762aed-a0d1-466c-9388-7d9a060b3c4a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added 'isFirstSynchronization' to options",
+  "packageName": "@itwin/imodel-transformer",
+  "email": "51540204+simsta6@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -601,7 +601,7 @@ export class IModelTransformer extends IModelExportHandler {
   /** Returns `true` if *brute force* delete detections should be run.
    * @note Not relevant for processChanges when change history is known.
    */
-  private shouldDetectDeletes(): boolean {
+  protected shouldDetectDeletes(): boolean {
     if (this._options.isFirstSynchronization)
       return false; // not necessary the first time since there are no deletes to detect
 


### PR DESCRIPTION
- Added isFirstSynchronizations to options
- Made shouldDetectDeletes method protected

If source iModel had different external source aspects, they were imported to target. Then at the end of transformation `detectElementsDeletes` was called. It would detect that some elements should be deleted, because transformer would get random identifier values, example:
![image](https://github.com/iTwin/imodel-transformer/assets/51540204/8350bc50-38e4-4469-ba6c-00a147c4b8fc)
