### PR TITLE
Fixed onDeleteModel "Missing Id" and "ForeignKey constraint" errors

### DIFF
--- a/change/@itwin-imodel-transformer-d19ae39b-d3bd-40b4-9258-ea5b3e9bec05.json
+++ b/change/@itwin-imodel-transformer-d19ae39b-d3bd-40b4-9258-ea5b3e9bec05.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added a fix for \"Missing id\" and \"ForeignKey constraint\" errors while using onDeleteModel",
+  "packageName": "@itwin/imodel-transformer",
+  "email": "deividas.davidavicius@bentley.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -983,8 +983,37 @@ export class IModelTransformer extends IModelExportHandler {
     // - If only the model is deleted, [[initFromExternalSourceAspects]] will have already remapped the underlying element since it still exists.
     // - If both were deleted, [[remapDeletedSourceElements]] will find and remap the deleted element making this operation valid
     const targetModelId: Id64String = this.context.findTargetElementId(sourceModelId);
-    if (Id64.isValidId64(targetModelId)) {
-      this.importer.deleteModel(targetModelId);
+    try {
+      if (Id64.isValidId64(targetModelId)) {
+        if (this.exporter.sourceDbChanges?.element.deleteIds.has(sourceModelId)) {
+          const targetPartitionElement = this.targetDb.elements.tryGetElement(targetModelId);
+          const isDefinitionPartition = targetPartitionElement && targetPartitionElement instanceof DefinitionPartition;
+          if (isDefinitionPartition) {
+            // Skipping model deletion because model's partition will also be deleted.
+            // It expects that model will be present and will fail if it's missing.
+            // Model will be deleted when its partition will be deleted.
+            return;
+          }
+        }
+        this.importer.deleteModel(targetModelId);
+      }
+    } catch (error) {
+      const isDeletionProhibitedErr = error instanceof IModelError && (error.errorNumber === IModelStatus.DeletionProhibited || error.errorNumber === IModelStatus.ForeignKeyConstraint);
+      if (!isDeletionProhibitedErr)
+        throw error;
+
+      // Transformer tries to delete models before it deletes elements. Definition models cannot be deleted unless all of their modeled elements are deleted first.
+      // In case a definition model needs to be deleted we need to skip it for now and register its modeled partition for deletion.
+      // The `OnDeleteElement` calls `DeleteElementTree` Which deletes the model together with its partition after deleting all of the modeled elements.
+      this.scheduleModeledPartitionDeletion(sourceModelId);
+    }
+  }
+
+  /** Schedule modeled partition deletion */
+  private scheduleModeledPartitionDeletion(sourceModelId: Id64String): void {
+    const deletedElements = this.exporter.sourceDbChanges?.element.deleteIds as Set<Id64String>;
+    if (!deletedElements.has(sourceModelId)) {
+      deletedElements.add(sourceModelId);
     }
   }
 

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -990,7 +990,7 @@ export class IModelTransformer extends IModelExportHandler {
     if (this.exporter.sourceDbChanges?.element.deleteIds.has(sourceModelId)) {
       const isDefinitionPartition = this.targetDb.withPreparedStatement(`
         SELECT 1
-        FROM bis.DefinitionElement
+        FROM bis.DefinitionPartition
         WHERE ECInstanceId=?
       `, (stmt) => {
         stmt.bindId(1, targetModelId);

--- a/packages/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -194,7 +194,7 @@ describe("IModelTransformer", () => {
       assert.equal(targetImporter.numModelsUpdated, 0);
       assert.equal(targetImporter.numElementsInserted, 1);
       assert.equal(targetImporter.numElementsUpdated, 5);
-      assert.equal(targetImporter.numElementsDeleted, 3);
+      assert.equal(targetImporter.numElementsDeleted, 4);
       assert.equal(targetImporter.numElementAspectsInserted, 0);
       assert.equal(targetImporter.numElementAspectsUpdated, 2);
       assert.equal(targetImporter.numRelationshipsInserted, 2);
@@ -264,7 +264,7 @@ describe("IModelTransformer", () => {
     branchToMasterTransformer.dispose();
     masterDb.saveChanges();
     TransformerExtensiveTestScenario.assertUpdatesInDb(masterDb, false);
-    assert.equal(numBranchElements, count(masterDb, Element.classFullName) - 4); // processAll cannot detect deletes when isReverseSynchronization=true
+    assert.equal(numBranchElements, count(masterDb, Element.classFullName) - 5); // processAll cannot detect deletes when isReverseSynchronization=true
     assert.equal(numBranchRelationships, count(masterDb, ElementRefersToElements.classFullName) - 1); // processAll cannot detect deletes when isReverseSynchronization=true
     assert.equal(0, count(masterDb, ExternalSourceAspect.classFullName));
 


### PR DESCRIPTION
"Missing Id: error deleting model" error:
Added a fix and test for "Missing Id: error deleting model" which occured because onDeleteModel deleted definition model. It shouldn't delete definition model in onDeleteModel if its partition element will also be deleted, because elementTreeDeleter deletes definition model while deleting definition partition element.

"ForeignKey Constraint: error deleting model" error:
Added a fix and test for this error. Transformer tries to delete models before it deletes elements. Definition models cannot be deleted unless all of their modeled elements are deleted first.