### PR TITLE
revert to original behavior of provenance ExternalSourceAspect version [fed guid branch]

### DIFF
--- a/change/@itwin-imodel-transformer-f333a974-ba76-439f-8059-001157e9a47c.json
+++ b/change/@itwin-imodel-transformer-f333a974-ba76-439f-8059-001157e9a47c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "revert to original behavior of provenance ExternalSourceAspect version behavior",
+  "packageName": "@itwin/imodel-transformer",
+  "email": "mike.belousov@bentley.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/transformer/src/BranchProvenanceInitializer.ts
+++ b/packages/transformer/src/BranchProvenanceInitializer.ts
@@ -126,6 +126,7 @@ export async function initializeBranchProvenance(args: ProvenanceInitArgs): Prom
       isReverseSynchronization: false,
       targetScopeElementId: masterExternalSourceId,
       sourceDb: args.master,
+      targetDb: args.branch,
     });
     args.branch.elements.insertAspect(aspectProps);
   }

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -461,11 +461,15 @@ export class IModelTransformer extends IModelExportHandler {
     targetElementId: Id64String,
     args: {
       sourceDb: IModelDb;
+      targetDb: IModelDb;
       isReverseSynchronization: boolean;
       targetScopeElementId: Id64String;
     },
   ): ExternalSourceAspectProps {
     const elementId = args.isReverseSynchronization ? sourceElementId : targetElementId;
+    const version = args.isReverseSynchronization
+      ? args.targetDb.elements.queryLastModifiedTime(targetElementId)
+      : args.sourceDb.elements.queryLastModifiedTime(sourceElementId);
     const aspectIdentifier = args.isReverseSynchronization ? targetElementId : sourceElementId;
     const aspectProps: ExternalSourceAspectProps = {
       classFullName: ExternalSourceAspect.classFullName,
@@ -473,7 +477,7 @@ export class IModelTransformer extends IModelExportHandler {
       scope: { id: args.targetScopeElementId },
       identifier: aspectIdentifier,
       kind: ExternalSourceAspect.Kind.Element,
-      version: args.sourceDb.elements.queryLastModifiedTime(sourceElementId),
+      version,
     };
     return aspectProps;
   }
@@ -538,6 +542,7 @@ export class IModelTransformer extends IModelExportHandler {
         isReverseSynchronization: !!this._options.isReverseSynchronization,
         targetScopeElementId: this.targetScopeElementId,
         sourceDb: this.sourceDb,
+        targetDb: this.targetDb,
       },
     );
   }

--- a/packages/transformer/src/test/standalone/IModelTransformerHub.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformerHub.test.ts
@@ -1869,7 +1869,7 @@ describe("IModelTransformerHub", () => {
       { master: { 1:1 } },
       { branch: { branch: "master" } },
       { branch: { 1:2 } },
-      { master: { sync: ["branch", 1] } },
+      { master: { sync: ["branch"] } },
       { assert({ master, branch }) {
         const elem1InMaster = TestUtils.IModelTestUtils.queryByUserLabel(master.db, "1");
         expect(elem1InMaster).not.to.be.undefined;
@@ -1883,7 +1883,11 @@ describe("IModelTransformerHub", () => {
       }},
     ];
 
-    const { tearDown } = await runTimeline(timeline, { iTwinId, accessToken });
+    const { tearDown } = await runTimeline(timeline, {
+      iTwinId,
+      accessToken,
+      transformerOpts: { forceExternalSourceAspectProvenance: true }
+    });
 
     await tearDown();
     sinon.restore();

--- a/packages/transformer/src/test/standalone/IModelTransformerHub.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformerHub.test.ts
@@ -1863,5 +1863,30 @@ describe("IModelTransformerHub", () => {
     await tearDown();
     sinon.restore();
   });
+
+  it("should use the lastMod of provenanceDb's element as the provenance aspect version", async () => {
+    const timeline: Timeline = [
+      { master: { 1:1 } },
+      { branch: { branch: "master" } },
+      { branch: { 1:2 } },
+      { master: { sync: ["branch", 1] } },
+      { assert({ master, branch }) {
+        const elem1InMaster = TestUtils.IModelTestUtils.queryByUserLabel(master.db, "1");
+        expect(elem1InMaster).not.to.be.undefined;
+        const elem1InBranch = TestUtils.IModelTestUtils.queryByUserLabel(branch.db, "1");
+        expect(elem1InBranch).not.to.be.undefined;
+        const lastModInMaster = master.db.elements.queryLastModifiedTime(elem1InMaster);
+
+        const physElem1Esas = branch.db.elements.getAspects(elem1InBranch, ExternalSourceAspect.classFullName) as ExternalSourceAspect[];
+        expect(physElem1Esas).to.have.lengthOf(1);
+        expect(physElem1Esas[0].version).to.equal(lastModInMaster);
+      }},
+    ];
+
+    const { tearDown } = await runTimeline(timeline, { iTwinId, accessToken });
+
+    await tearDown();
+    sinon.restore();
+  });
 });
 


### PR DESCRIPTION
forwardport of https://github.com/iTwin/imodel-transformer/pull/120