### PR TITLE
Handle duplicate code values when updating elements

### DIFF
--- a/packages/transformer/src/IModelImporter.ts
+++ b/packages/transformer/src/IModelImporter.ts
@@ -108,7 +108,6 @@ export class IModelImporter implements Required<IModelImportOptions> {
    * A guid string that is used to prefix duplicate code values when performing element updates.
    * The duplicate code value prefixing solves an issue when an element update fails because of a duplicate Element CodeValue in cases where
    * the duplicate target element is set to be deleted in the future, or when elements are switching code values with one another and we need a temporary code value.
-   * Using NULL code values as an alternative is not valid because definition elements cannot have NULL code values.
    * To remove prefixes call [[IModelImporter.resolveDuplicateCodeValues]].
    *
    * @returns undefined if no duplicates were detected.
@@ -238,6 +237,7 @@ export class IModelImporter implements Required<IModelImportOptions> {
           this.onUpdateElement(elementProps);
         } catch(err) {
           if (this.handleElementCodeDuplicates && (err as IModelError).errorNumber === IModelStatus.DuplicateCode) {
+            // Using NULL code values as an alternative is not valid because definition elements cannot have NULL code values.
             this.prefixCode(elementProps);
             this.onUpdateElement(elementProps);
           } else {

--- a/packages/transformer/src/IModelImporter.ts
+++ b/packages/transformer/src/IModelImporter.ts
@@ -5,13 +5,13 @@
 /** @packageDocumentation
  * @module iModels
  */
-import { CompressedId64Set, Id64, Id64String, IModelStatus, Logger } from "@itwin/core-bentley";
+import { CompressedId64Set, DbResult, Guid, GuidString, Id64, Id64String, IModelStatus, Logger } from "@itwin/core-bentley";
 import {
   AxisAlignedBox3d, Base64EncodedString, ElementAspectProps, ElementProps, EntityProps, IModel, IModelError, ModelProps, PrimitiveTypeCode,
   PropertyMetaData, RelatedElement, SubCategoryProps,
 } from "@itwin/core-common";
 import { TransformerLoggerCategory } from "./TransformerLoggerCategory";
-import { ElementAspect, ElementMultiAspect, Entity, IModelDb, Relationship, RelationshipProps, SourceAndTarget, SubCategory } from "@itwin/core-backend";
+import { ECSqlStatement, Element, ElementAspect, ElementMultiAspect, Entity, IModelDb, Relationship, RelationshipProps, SourceAndTarget, SubCategory } from "@itwin/core-backend";
 import type { IModelTransformOptions } from "./IModelTransformer";
 import * as assert from "assert";
 import { deleteElementTreeCascade } from "./ElementCascadingDeleter";
@@ -44,8 +44,8 @@ export interface IModelImportOptions {
    * @default false
    */
   simplifyElementGeometry?: boolean;
-  /** If 'true', try to handle conflicting code value changes by using temporary NULL values.
-   * Code values can be resolved by calling [[IModelImporter.resolveDuplicateCodeValues]].
+  /** If 'true', try to handle duplicate code value changes by prefixing them with a guid value.
+   * Prefixes can be removed by calling [[IModelImporter.resolveDuplicateCodeValues]].
    * @default false
    */
   handleElementCodeDuplicates?: boolean;
@@ -103,19 +103,17 @@ export class IModelImporter implements Required<IModelImportOptions> {
 
   private static _realityDataSourceLinkPartitionStaticId: Id64String = "0xe";
 
-  private _duplicateCodeValueMap?: Map<Id64String, string>;
-
+  private _duplicateCodeValuePrefix?: GuidString;
   /**
-   * A map of conflicting element code values.
-   * In cases where updating an element's code value results in a codeValue conflict, the element's code value will instead be updated to 'NULL'.
-   * The actual codeValue will be stored in this ElementId->CodeValue map.
-   * This is needed cases where the duplicate target element is set to be deleted in the future, or when elements are switching code values with one another and we need a temporary code value.
-   * To resolve code values to their intended values call [[IModelImporter.resolveDuplicateCodeValues]].
+   * A guid string that is used to prefix duplicate code values when performing element updates.
+   * The duplicate code value prefixing solves an issue when an element update fails because of a duplicate Element CodeValue in cases where
+   * the duplicate target element is set to be deleted in the future, or when elements are switching code values with one another and we need a temporary code value.
+   * To remove prefixes call [[IModelImporter.resolveDuplicateCodeValues]].
    *
    * @returns undefined if no duplicates were detected.
    */
-  public get duplicateCodeValueMap(): Map<Id64String, string> | undefined {
-    return this._duplicateCodeValueMap;
+  public get duplicateCodeValuePrefix(): GuidString | undefined {
+    return this._duplicateCodeValuePrefix;
   }
 
   public get handleElementCodeDuplicates(): boolean {
@@ -239,9 +237,7 @@ export class IModelImporter implements Required<IModelImportOptions> {
           this.onUpdateElement(elementProps);
         } catch(err) {
           if (this.handleElementCodeDuplicates && (err as IModelError).errorNumber === IModelStatus.DuplicateCode) {
-            assert(elementProps.code.value !== undefined, "NULL code values are always considered unique and cannot clash");
-            this.trackCodeValueDuplicate(elementProps.id, elementProps.code.value);
-            elementProps.code.value = undefined;
+            this.prefixCode(elementProps);
             this.onUpdateElement(elementProps);
           } else {
             throw err;
@@ -621,7 +617,7 @@ export class IModelImporter implements Required<IModelImportOptions> {
     // TODO: fix upstream, looks like a bad case for the linter rule when casting away readonly for this generic
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     (this.doNotUpdateElementIds as Set<Id64String>) = CompressedId64Set.decompressSet(state.doNotUpdateElementIds);
-    this._duplicateCodeValueMap =  state.duplicateCodeValueMap ? new Map(Object.entries(state.duplicateCodeValueMap)) : undefined;
+    this._duplicateCodeValuePrefix = state.duplicateCodeValuePrefix;
     this.loadAdditionalStateJson(state.additionalState);
   }
 
@@ -637,27 +633,35 @@ export class IModelImporter implements Required<IModelImportOptions> {
       options: this.options,
       targetDbId: this.targetDb.iModelId || this.targetDb.nativeDb.getFilePath(),
       doNotUpdateElementIds: CompressedId64Set.compressSet(this.doNotUpdateElementIds),
-      duplicateCodeValueMap: this._duplicateCodeValueMap ? Object.fromEntries(this._duplicateCodeValueMap) : undefined,
+      duplicateCodeValuePrefix: this._duplicateCodeValuePrefix,
       additionalState: this.getAdditionalStateJson(),
     };
   }
 
   public resolveDuplicateCodeValues(): void {
-    if (!this.handleElementCodeDuplicates || !this._duplicateCodeValueMap)
+    if (!this.handleElementCodeDuplicates || !this._duplicateCodeValuePrefix)
       return;
 
-    for (const [elementId, codeValue] of this._duplicateCodeValueMap) {
-      const element = this.targetDb.elements.getElement(elementId);
-      element.code.value = codeValue;
-      element.update();
-    }
+    this.targetDb.withPreparedStatement(`SELECT ECInstanceId FROM ${Element.classFullName} WHERE CodeValue LIKE '${this._duplicateCodeValuePrefix}%'`, (stmt: ECSqlStatement) => {
+      while (stmt.step() === DbResult.BE_SQLITE_ROW) {
+        const element = this.targetDb.elements.getElement(stmt.getValue(0).getId());
+        this.removeCodePrefix(element);
+        element.update();
+      }
+    });
+    this._duplicateCodeValuePrefix = undefined;
   }
 
-  private trackCodeValueDuplicate(targetElementId: Id64String, codeValue: string) {
-    if (!this._duplicateCodeValueMap)
-      this._duplicateCodeValueMap = new Map<Id64String, string> ();
+  private prefixCode(elementProps: ElementProps){
+    if (!this._duplicateCodeValuePrefix)
+      this._duplicateCodeValuePrefix = Guid.createValue();
+    elementProps.code.value = `${this._duplicateCodeValuePrefix}${elementProps.code.value}`;
+  }
 
-    this._duplicateCodeValueMap.set(targetElementId, codeValue);
+  private removeCodePrefix(element: Element): void {
+    if(!this._duplicateCodeValuePrefix)
+      return;
+    element.code.value = element.code.value.substring(this._duplicateCodeValuePrefix.length);
   }
 }
 
@@ -674,7 +678,7 @@ export interface IModelImporterState {
   options: IModelImportOptions;
   targetDbId: string;
   doNotUpdateElementIds: CompressedId64Set;
-  duplicateCodeValueMap?: Record<Id64String, string>;
+  duplicateCodeValuePrefix?: GuidString;
   additionalState?: any;
 }
 

--- a/packages/transformer/src/IModelImporter.ts
+++ b/packages/transformer/src/IModelImporter.ts
@@ -108,6 +108,7 @@ export class IModelImporter implements Required<IModelImportOptions> {
    * A guid string that is used to prefix duplicate code values when performing element updates.
    * The duplicate code value prefixing solves an issue when an element update fails because of a duplicate Element CodeValue in cases where
    * the duplicate target element is set to be deleted in the future, or when elements are switching code values with one another and we need a temporary code value.
+   * Using NULL code values as an alternative is not valid because definition elements cannot have NULL code values.
    * To remove prefixes call [[IModelImporter.resolveDuplicateCodeValues]].
    *
    * @returns undefined if no duplicates were detected.

--- a/packages/transformer/src/IModelImporter.ts
+++ b/packages/transformer/src/IModelImporter.ts
@@ -631,13 +631,14 @@ export class IModelImporter implements Required<IModelImportOptions> {
       element.code.value = codeValue;
       element.update();
     }
+    this._duplicateCodeValueMap.clear();
   }
 
   /**
    * Needs to be called to perform necessary cleanup operations.
    * By not calling `finalize` there is a risk that data imported into targetDb will not be as expected.
    *
-   * @internal
+   * @note No need to call this If using [[IModelTransformer]] as it automatically invokes this method.
    */
   public finalize(): void {
     this.resolveDuplicateCodeValues();

--- a/packages/transformer/src/IModelImporter.ts
+++ b/packages/transformer/src/IModelImporter.ts
@@ -243,6 +243,8 @@ export class IModelImporter implements Required<IModelImportOptions> {
             this.trackCodeValueDuplicate(elementProps.id, elementProps.code.value);
             elementProps.code.value = undefined;
             this.onUpdateElement(elementProps);
+          } else {
+            throw err;
           }
         }
       } else {

--- a/packages/transformer/src/IModelImporter.ts
+++ b/packages/transformer/src/IModelImporter.ts
@@ -5,13 +5,13 @@
 /** @packageDocumentation
  * @module iModels
  */
-import { CompressedId64Set, DbResult, Guid, GuidString, Id64, Id64String, IModelStatus, Logger } from "@itwin/core-bentley";
+import { CompressedId64Set, Guid, Id64, Id64String, IModelStatus, Logger } from "@itwin/core-bentley";
 import {
   AxisAlignedBox3d, Base64EncodedString, ElementAspectProps, ElementProps, EntityProps, IModel, IModelError, ModelProps, PrimitiveTypeCode,
   PropertyMetaData, RelatedElement, SubCategoryProps,
 } from "@itwin/core-common";
 import { TransformerLoggerCategory } from "./TransformerLoggerCategory";
-import { ECSqlStatement, Element, ElementAspect, ElementMultiAspect, Entity, IModelDb, Relationship, RelationshipProps, SourceAndTarget, SubCategory } from "@itwin/core-backend";
+import { ElementAspect, ElementMultiAspect, Entity, IModelDb, Relationship, RelationshipProps, SourceAndTarget, SubCategory } from "@itwin/core-backend";
 import type { IModelTransformOptions } from "./IModelTransformer";
 import * as assert from "assert";
 import { deleteElementTreeCascade } from "./ElementCascadingDeleter";
@@ -44,8 +44,8 @@ export interface IModelImportOptions {
    * @default false
    */
   simplifyElementGeometry?: boolean;
-  /** If 'true', try to handle duplicate code value changes by prefixing them with a guid value.
-   * Prefixes can be removed by calling [[IModelImporter.resolveDuplicateCodeValues]].
+  /** If 'true', try to handle conflicting code value changes by using temporary guid values.
+   * Code values can be resolved by calling [[IModelImporter.resolveDuplicateCodeValues]].
    * @default false
    */
   handleElementCodeDuplicates?: boolean;
@@ -103,17 +103,19 @@ export class IModelImporter implements Required<IModelImportOptions> {
 
   private static _realityDataSourceLinkPartitionStaticId: Id64String = "0xe";
 
-  private _duplicateCodeValuePrefix?: GuidString;
+  private _duplicateCodeValueMap?: Map<Id64String, string>;
+
   /**
-   * A guid string that is used to prefix duplicate code values when performing element updates.
-   * The duplicate code value prefixing solves an issue when an element update fails because of a duplicate Element CodeValue in cases where
-   * the duplicate target element is set to be deleted in the future, or when elements are switching code values with one another and we need a temporary code value.
-   * To remove prefixes call [[IModelImporter.resolveDuplicateCodeValues]].
+   * A map of conflicting element code values.
+   * In cases where updating an element's code value results in a codeValue conflict, the element's code value will instead be updated to a random guid.
+   * The actual codeValue will be stored in this ElementId->CodeValue map.
+   * This is needed in cases where the duplicate target element is set to be deleted in the future, or when elements are switching code values with one another and we need a temporary code value.
+   * To resolve code values to their intended values call [[IModelImporter.resolveDuplicateCodeValues]].
    *
    * @returns undefined if no duplicates were detected.
    */
-  public get duplicateCodeValuePrefix(): GuidString | undefined {
-    return this._duplicateCodeValuePrefix;
+  public get duplicateCodeValueMap(): Map<Id64String, string> | undefined {
+    return this._duplicateCodeValueMap;
   }
 
   public get handleElementCodeDuplicates(): boolean {
@@ -237,8 +239,10 @@ export class IModelImporter implements Required<IModelImportOptions> {
           this.onUpdateElement(elementProps);
         } catch(err) {
           if (this.handleElementCodeDuplicates && (err as IModelError).errorNumber === IModelStatus.DuplicateCode) {
+            assert(elementProps.code.value !== undefined, "NULL code values are always considered unique and cannot clash");
+            this.trackCodeValueDuplicate(elementProps.id, elementProps.code.value);
             // Using NULL code values as an alternative is not valid because definition elements cannot have NULL code values.
-            this.prefixCode(elementProps);
+            elementProps.code.value = Guid.createValue();
             this.onUpdateElement(elementProps);
           } else {
             throw err;
@@ -618,7 +622,7 @@ export class IModelImporter implements Required<IModelImportOptions> {
     // TODO: fix upstream, looks like a bad case for the linter rule when casting away readonly for this generic
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     (this.doNotUpdateElementIds as Set<Id64String>) = CompressedId64Set.decompressSet(state.doNotUpdateElementIds);
-    this._duplicateCodeValuePrefix = state.duplicateCodeValuePrefix;
+    this._duplicateCodeValueMap =  state.duplicateCodeValueMap ? new Map(Object.entries(state.duplicateCodeValueMap)) : undefined;
     this.loadAdditionalStateJson(state.additionalState);
   }
 
@@ -634,35 +638,27 @@ export class IModelImporter implements Required<IModelImportOptions> {
       options: this.options,
       targetDbId: this.targetDb.iModelId || this.targetDb.nativeDb.getFilePath(),
       doNotUpdateElementIds: CompressedId64Set.compressSet(this.doNotUpdateElementIds),
-      duplicateCodeValuePrefix: this._duplicateCodeValuePrefix,
+      duplicateCodeValueMap: this._duplicateCodeValueMap ? Object.fromEntries(this._duplicateCodeValueMap) : undefined,
       additionalState: this.getAdditionalStateJson(),
     };
   }
 
   public resolveDuplicateCodeValues(): void {
-    if (!this.handleElementCodeDuplicates || !this._duplicateCodeValuePrefix)
+    if (!this.handleElementCodeDuplicates || !this._duplicateCodeValueMap)
       return;
 
-    this.targetDb.withPreparedStatement(`SELECT ECInstanceId FROM ${Element.classFullName} WHERE CodeValue LIKE '${this._duplicateCodeValuePrefix}%'`, (stmt: ECSqlStatement) => {
-      while (stmt.step() === DbResult.BE_SQLITE_ROW) {
-        const element = this.targetDb.elements.getElement(stmt.getValue(0).getId());
-        this.removeCodePrefix(element);
-        element.update();
-      }
-    });
-    this._duplicateCodeValuePrefix = undefined;
+    for (const [elementId, codeValue] of this._duplicateCodeValueMap) {
+      const element = this.targetDb.elements.getElement(elementId);
+      element.code.value = codeValue;
+      element.update();
+    }
   }
 
-  private prefixCode(elementProps: ElementProps){
-    if (!this._duplicateCodeValuePrefix)
-      this._duplicateCodeValuePrefix = Guid.createValue();
-    elementProps.code.value = `${this._duplicateCodeValuePrefix}${elementProps.code.value}`;
-  }
+  private trackCodeValueDuplicate(targetElementId: Id64String, codeValue: string) {
+    if (!this._duplicateCodeValueMap)
+      this._duplicateCodeValueMap = new Map<Id64String, string> ();
 
-  private removeCodePrefix(element: Element): void {
-    if(!this._duplicateCodeValuePrefix)
-      return;
-    element.code.value = element.code.value.substring(this._duplicateCodeValuePrefix.length);
+    this._duplicateCodeValueMap.set(targetElementId, codeValue);
   }
 }
 
@@ -679,7 +675,7 @@ export interface IModelImporterState {
   options: IModelImportOptions;
   targetDbId: string;
   doNotUpdateElementIds: CompressedId64Set;
-  duplicateCodeValuePrefix?: GuidString;
+  duplicateCodeValueMap?: Record<Id64String, string>;
   additionalState?: any;
 }
 

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -180,6 +180,14 @@ export interface IModelTransformOptions {
    * @default false
    */
   ignoreMissingChangesetsInSynchronizations?: boolean;
+
+  /**
+   * Prefix duplicate code values with a temporary guid value when performing an element update.
+   * The duplicate code value prefixing solves an issue when an element update fails because of a duplicate Element CodeValue in cases where
+   * the duplicate target element is set to be deleted in the future, or when elements are switching code values with one another and we need a temporary code value.
+   * These prefixes will be removed during [[finalizeTransformation]].
+   */
+  handleElementCodeDuplicates?: boolean;
 }
 
 /**
@@ -377,9 +385,10 @@ export class IModelTransformer extends IModelExportHandler {
     this.exporter.excludeElementAspectClass("BisCore:TextAnnotationData"); // This ElementAspect is auto-created by the BisCore:TextAnnotation2d/3d element handlers
     // initialize importer and targetDb
     if (target instanceof IModelDb) {
-      this.importer = new IModelImporter(target, { preserveElementIdsForFiltering: this._options.preserveElementIdsForFiltering });
+      this.importer = new IModelImporter(target, { preserveElementIdsForFiltering: this._options.preserveElementIdsForFiltering, handleElementCodeDuplicates: this._options.handleElementCodeDuplicates });
     } else {
       this.importer = target;
+      this.importer.handleElementCodeDuplicates = !!this._options.handleElementCodeDuplicates;
       /* eslint-disable deprecation/deprecation */
       if (Boolean(this._options.preserveElementIdsForFiltering) !== this.importer.preserveElementIdsForFiltering) {
         Logger.logWarning(
@@ -1847,6 +1856,7 @@ export class IModelTransformer extends IModelExportHandler {
 
   // FIXME: is this necessary when manually using lowlevel transform APIs?
   private finalizeTransformation() {
+    this.importer.resolveConflictingCodeValues();
     this.updateSynchronizationVersion();
 
     if (this._partiallyCommittedEntities.size > 0) {

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -181,11 +181,12 @@ export interface IModelTransformOptions {
    */
   ignoreMissingChangesetsInSynchronizations?: boolean;
 
-  /**
-   * Prefix duplicate code values with a temporary guid value when performing an element update.
-   * The duplicate code value prefixing solves an issue when an element update fails because of a duplicate Element CodeValue in cases where
-   * the duplicate target element is set to be deleted in the future, or when elements are switching code values with one another and we need a temporary code value.
-   * These prefixes will be removed during [[finalizeTransformation]].
+  /** If 'true', try to handle conflicting code value changes by using temporary NULL values.
+   * This solves an issue when an element update fails because of a duplicate Element CodeValue in cases where the duplicate target element is set to be deleted in the future,
+   * or when elements are switching code values with one another and we need a temporary code value.
+   * Code values will be resolved to their intended values during [[finalizeTransformation]].
+   *
+   * @default false
    */
   handleElementCodeDuplicates?: boolean;
 }
@@ -1856,7 +1857,7 @@ export class IModelTransformer extends IModelExportHandler {
 
   // FIXME: is this necessary when manually using lowlevel transform APIs?
   private finalizeTransformation() {
-    this.importer.resolveConflictingCodeValues();
+    this.importer.resolveDuplicateCodeValues();
     this.updateSynchronizationVersion();
 
     if (this._partiallyCommittedEntities.size > 0) {

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -181,11 +181,12 @@ export interface IModelTransformOptions {
    */
   ignoreMissingChangesetsInSynchronizations?: boolean;
 
-  /**
-   * Prefix duplicate code values with a temporary guid value when performing an element update.
-   * The duplicate code value prefixing solves an issue when an element update fails because of a duplicate Element CodeValue in cases where
-   * the duplicate target element is set to be deleted in the future, or when elements are switching code values with one another and we need a temporary code value.
-   * These prefixes will be removed during [[finalizeTransformation]].
+  /** If 'true', try to handle conflicting code value changes by using temporary guid values.
+   * This solves an issue when an element update fails because of a duplicate Element CodeValue in cases where the duplicate target element is set to be deleted in the future,
+   * or when elements are switching code values with one another and we need a temporary code value.
+   * Code values will be resolved to their intended values during [[finalizeTransformation]].
+   *
+   * @default false
    */
   handleElementCodeDuplicates?: boolean;
 }

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -181,12 +181,11 @@ export interface IModelTransformOptions {
    */
   ignoreMissingChangesetsInSynchronizations?: boolean;
 
-  /** If 'true', try to handle conflicting code value changes by using temporary NULL values.
-   * This solves an issue when an element update fails because of a duplicate Element CodeValue in cases where the duplicate target element is set to be deleted in the future,
-   * or when elements are switching code values with one another and we need a temporary code value.
-   * Code values will be resolved to their intended values during [[finalizeTransformation]].
-   *
-   * @default false
+  /**
+   * Prefix duplicate code values with a temporary guid value when performing an element update.
+   * The duplicate code value prefixing solves an issue when an element update fails because of a duplicate Element CodeValue in cases where
+   * the duplicate target element is set to be deleted in the future, or when elements are switching code values with one another and we need a temporary code value.
+   * These prefixes will be removed during [[finalizeTransformation]].
    */
   handleElementCodeDuplicates?: boolean;
 }
@@ -1857,7 +1856,7 @@ export class IModelTransformer extends IModelExportHandler {
 
   // FIXME: is this necessary when manually using lowlevel transform APIs?
   private finalizeTransformation() {
-    this.importer.resolveDuplicateCodeValues();
+    this.importer.resolveConflictingCodeValues();
     this.updateSynchronizationVersion();
 
     if (this._partiallyCommittedEntities.size > 0) {

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -180,15 +180,6 @@ export interface IModelTransformOptions {
    * @default false
    */
   ignoreMissingChangesetsInSynchronizations?: boolean;
-
-  /** If 'true', try to handle conflicting code value changes by using temporary guid values.
-   * This solves an issue when an element update fails because of a duplicate Element CodeValue in cases where the duplicate target element is set to be deleted in the future,
-   * or when elements are switching code values with one another and we need a temporary code value.
-   * Code values will be resolved to their intended values during [[finalizeTransformation]].
-   *
-   * @default false
-   */
-  handleElementCodeDuplicates?: boolean;
 }
 
 /**
@@ -386,10 +377,9 @@ export class IModelTransformer extends IModelExportHandler {
     this.exporter.excludeElementAspectClass("BisCore:TextAnnotationData"); // This ElementAspect is auto-created by the BisCore:TextAnnotation2d/3d element handlers
     // initialize importer and targetDb
     if (target instanceof IModelDb) {
-      this.importer = new IModelImporter(target, { preserveElementIdsForFiltering: this._options.preserveElementIdsForFiltering, handleElementCodeDuplicates: this._options.handleElementCodeDuplicates });
+      this.importer = new IModelImporter(target, { preserveElementIdsForFiltering: this._options.preserveElementIdsForFiltering });
     } else {
       this.importer = target;
-      this.importer.handleElementCodeDuplicates = !!this._options.handleElementCodeDuplicates;
       /* eslint-disable deprecation/deprecation */
       if (Boolean(this._options.preserveElementIdsForFiltering) !== this.importer.preserveElementIdsForFiltering) {
         Logger.logWarning(
@@ -1855,9 +1845,9 @@ export class IModelTransformer extends IModelExportHandler {
     });
   }
 
-  // FIXME: is this necessary when manually using lowlevel transform APIs?
+  // FIXME: is this necessary when manually using low level transform APIs?
   private finalizeTransformation() {
-    this.importer.resolveDuplicateCodeValues();
+    this.importer.finalize();
     this.updateSynchronizationVersion();
 
     if (this._partiallyCommittedEntities.size > 0) {

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -1856,7 +1856,7 @@ export class IModelTransformer extends IModelExportHandler {
 
   // FIXME: is this necessary when manually using lowlevel transform APIs?
   private finalizeTransformation() {
-    this.importer.resolveConflictingCodeValues();
+    this.importer.resolveDuplicateCodeValues();
     this.updateSynchronizationVersion();
 
     if (this._partiallyCommittedEntities.size > 0) {

--- a/packages/transformer/src/test/standalone/IModelTransformerHub.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformerHub.test.ts
@@ -1893,7 +1893,7 @@ describe("IModelTransformerHub", () => {
     sinon.restore();
   });
 
-  it.only("should successfully process changes when codeValues are switched around between elements", async () => {
+  it("should successfully process changes when codeValues are switched around between elements", async () => {
     const timeline: Timeline = [
       { master: { 1:1, 2:2, 3:3 } },
       { branch: { branch: "master" } },

--- a/packages/transformer/src/test/standalone/IModelTransformerHub.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformerHub.test.ts
@@ -1287,7 +1287,7 @@ describe("IModelTransformerHub", () => {
     sinon.restore();
   });
 
-  it("should reverse synchronize forked iModel when an element was updated", async() => {
+  it("should reverse synchronize forked iModel when an element was updated", async () => {
     const sourceIModelName: string = IModelTransformerTestUtils.generateUniqueName("Master");
     const sourceIModelId = await HubWrappers.recreateIModel({ accessToken, iTwinId, iModelName: sourceIModelName, noLocks: true });
     assert.isTrue(Guid.isGuid(sourceIModelId));
@@ -1306,7 +1306,7 @@ describe("IModelTransformerHub", () => {
         model: modelId,
         category: categoryId,
         code: Code.createEmpty(),
-        userLabel: "Element1"
+        userLabel: "Element1",
       };
       const originalElementId = sourceDb.elements.insertElement(physicalElement);
 
@@ -1742,7 +1742,7 @@ describe("IModelTransformerHub", () => {
     await tearDown();
   });
 
-  it("should successfully remove element in master iModel after reverse synchronization when elements have random ExternalSourceAspects", async() => {
+  it("should successfully remove element in master iModel after reverse synchronization when elements have random ExternalSourceAspects", async () => {
     const timeline: Timeline = [
       { master: { 1:1 } },
       { master: { manualUpdate(masterDb) {
@@ -1886,7 +1886,7 @@ describe("IModelTransformerHub", () => {
     const { tearDown } = await runTimeline(timeline, {
       iTwinId,
       accessToken,
-      transformerOpts: { forceExternalSourceAspectProvenance: true }
+      transformerOpts: { forceExternalSourceAspectProvenance: true },
     });
 
     await tearDown();
@@ -1929,7 +1929,7 @@ describe("IModelTransformerHub", () => {
       }},
     ];
 
-    const { tearDown } = await runTimeline(timeline, { iTwinId, accessToken, transformerOpts: { handleElementCodeDuplicates: true } });
+    const { tearDown } = await runTimeline(timeline, { iTwinId, accessToken });
     await tearDown();
   });
 
@@ -1965,7 +1965,7 @@ describe("IModelTransformerHub", () => {
       }},
     ];
 
-    const { tearDown } = await runTimeline(timeline, { iTwinId, accessToken, transformerOpts: { handleElementCodeDuplicates: true } });
+    const { tearDown } = await runTimeline(timeline, { iTwinId, accessToken });
     await tearDown();
   });
 });


### PR DESCRIPTION
This change allows processing of changes where Element CodeValues have been switched with one another