### PR TITLE
Added API for querying provenance info for derived transformer classes

### DIFF
--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -645,13 +645,13 @@ export class IModelTransformer extends IModelExportHandler {
    */
   protected tryGetProvenanceScopeAspect(): ExternalSourceAspect | undefined {
     const sql = `
-    SELECT ECInstanceId
-    FROM ${ExternalSourceAspect.classFullName}
-    WHERE Scope.Id = :scopeId
-      AND Kind = :kind
-      AND Element.Id = :elementId
-      AND Identifier = :identifier
-    LIMIT 1`;
+      SELECT ECInstanceId
+      FROM ${ExternalSourceAspect.classFullName}
+      WHERE Scope.Id = :scopeId
+        AND Kind = :kind
+        AND Element.Id = :elementId
+        AND Identifier = :identifier
+      LIMIT 1`;
 
     const scopeProvenanceAspectId = this.provenanceDb.withPreparedStatement(sql, (stmt) => {
       stmt.bindId("scopeId", IModel.rootSubjectId);

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -206,6 +206,11 @@ class PartiallyCommittedEntity {
   }
 }
 
+/**
+ * Data type for persisting change version information within provenance Scope ExternalSourceAspect.
+ * Additionally, forward synchronization version is stored in Scope aspect's 'version' field.
+ * @beta
+ */
 export interface TargetScopeProvenanceJsonProps {
   pendingReverseSyncChangesetIndices: number[];
   pendingSyncChangesetIndices: number[];

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -206,7 +206,7 @@ class PartiallyCommittedEntity {
   }
 }
 
-interface TargetScopeProvenanceJsonProps {
+export interface TargetScopeProvenanceJsonProps {
   pendingReverseSyncChangesetIndices: number[];
   pendingSyncChangesetIndices: number[];
   reverseSyncVersion: string;


### PR DESCRIPTION
Added methods that allow derived transformer classes to query synchronization version and provenance Scope aspect.

- Federation guid branch is not backwards compatible when it comes to supporting old branches. Exposing api to access scope aspect is necessary so that derived classes can fake the synchronization version themselves.
- Exporting TargetScopeProvenanceJsonProps for derived classes to make sense of 'Scope' aspect's jsonProps.
- explicitly calling `initialize` will throw errors if scope provenance is not initialized in change processing workflow. Exposed `initScopeProvenance` to derived classes.
