### PR TITLE
Move aspect processing before any clean up is started in change processing

### DIFF
--- a/packages/transformer/src/IModelExporter.ts
+++ b/packages/transformer/src/IModelExporter.ts
@@ -356,6 +356,7 @@ export class IModelExporter {
     await this.exportFonts();
     await this.exportModelContents(IModel.repositoryModelId);
     await this.exportSubModels(IModel.repositoryModelId);
+    await this.exportAllAspects();
     await this.exportRelationships(ElementRefersToElements.classFullName);
 
     // handle deletes

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -2663,7 +2663,6 @@ export class IModelTransformer extends IModelExportHandler {
     // must wait for initialization of synchronization provenance data
     await this.exporter.exportChanges(this.getExportInitOpts(args));
     await this.processDeferredElements(); // eslint-disable-line deprecation/deprecation
-    await this.exporter["exportAllAspects"](); // eslint-disable-line @typescript-eslint/dot-notation
 
     if (this._options.optimizeGeometry)
       this.importer.optimizeGeometry(this._options.optimizeGeometry);


### PR DESCRIPTION
While experimenting locally, I found out that `IModelExporter.sourceDbChanges` is cleaned up before aspects are processed. It doesn't brake existing strategies, but if another strategy is added or package consumers add their own custom strategy it might lead to bugs.