### PR TITLE
Add fix to handle max path limit in windows

### DIFF
--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -2151,7 +2151,9 @@ export class IModelTransformer extends IModelExportHandler {
     let schemaFileName = schema.name + ext;
     // many file systems have a max file-name/path-segment size of 255, so we workaround that on all systems
     const systemMaxPathSegmentSize = 255;
-    if (schemaFileName.length > systemMaxPathSegmentSize) {
+    // windows usually has a limit for the total path length of 256
+    const windowsMaxPathLimit = 256;
+    if (schemaFileName.length > systemMaxPathSegmentSize || path.join(this._schemaExportDir, schemaFileName).length >= windowsMaxPathLimit) {
       // this name should be well under 255 bytes
       // ( 100 + (Number.MAX_SAFE_INTEGER.toString().length = 16) + (ext.length = 13) ) = 129 which is less than 255
       // You'd have to be past 2**53-1 (Number.MAX_SAFE_INTEGER) long named schemas in order to hit decimal formatting,

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -2151,7 +2151,7 @@ export class IModelTransformer extends IModelExportHandler {
     let schemaFileName = schema.name + ext;
     // many file systems have a max file-name/path-segment size of 255, so we workaround that on all systems
     const systemMaxPathSegmentSize = 255;
-    // windows usually has a limit for the total path length of 256
+    // windows usually has a limit for the total path length of 260
     const windowsMaxPathLimit = 260;
     if (schemaFileName.length > systemMaxPathSegmentSize || path.join(this._schemaExportDir, schemaFileName).length >= windowsMaxPathLimit) {
       // this name should be well under 255 bytes

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -2152,7 +2152,7 @@ export class IModelTransformer extends IModelExportHandler {
     // many file systems have a max file-name/path-segment size of 255, so we workaround that on all systems
     const systemMaxPathSegmentSize = 255;
     // windows usually has a limit for the total path length of 256
-    const windowsMaxPathLimit = 256;
+    const windowsMaxPathLimit = 260;
     if (schemaFileName.length > systemMaxPathSegmentSize || path.join(this._schemaExportDir, schemaFileName).length >= windowsMaxPathLimit) {
       // this name should be well under 255 bytes
       // ( 100 + (Number.MAX_SAFE_INTEGER.toString().length = 16) + (ext.length = 13) ) = 129 which is less than 255


### PR DESCRIPTION
Windows has a max total path limit of 260 and there can be schemas which don't reach the max path segment size, but the full path reaches max total path limit in windows systems.