### PR TITLE
4.3.3 support

### DIFF
--- a/packages/performance-tests/test/iModelUtils.ts
+++ b/packages/performance-tests/test/iModelUtils.ts
@@ -27,7 +27,9 @@ export function setToStandalone(iModelPath: string) {
   nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned); // standalone iModels should always have BriefcaseId unassigned
   nativeDb.saveLocalValue("StandaloneEdit", JSON.stringify({ txns: true }));
   nativeDb.saveChanges(); // save change to briefcaseId
-  nativeDb.closeIModel();
+  // handle cross-version usage of internal API
+  (nativeDb as any)?.closeIModel?.();
+  (nativeDb as any)?.closeFile?.();
 }
 
 export function generateTestIModel(iModelParam: IModelParams): TestIModel {

--- a/packages/transformer/src/test/IModelTransformerUtils.ts
+++ b/packages/transformer/src/test/IModelTransformerUtils.ts
@@ -301,11 +301,16 @@ export async function assertIdentityTransformation(
             mappedRelationTargetInTargetId
           );
         } else if (!propChangesAllowed) {
-          // kept for conditional breakpoints
-          const _propEq = TestUtils.advancedDeepEqual(targetElem.asAny[propName], sourceElem.asAny[propName]);
-          expect(targetElem.asAny[propName]).to.deep.advancedEqual(
-            sourceElem.asAny[propName]
-          );
+          try {
+            expect(
+              (targetElem as any)[propName],
+              `${targetElem.id}[${propName}] didn't match ${sourceElem.id}[${propName}]`
+            ).to.deep.advancedEqual((sourceElem as any)[propName]);
+          } catch (err) {
+            // for debugging broken tests
+            debugger; // eslint-disable-line no-debugger
+            throw err;
+          }
         }
       }
       const quickClone = (obj: any) => JSON.parse(JSON.stringify(obj));

--- a/packages/transformer/src/test/IModelTransformerUtils.ts
+++ b/packages/transformer/src/test/IModelTransformerUtils.ts
@@ -235,13 +235,18 @@ export async function assertIdentityTransformation(
     // [IModelTransformerOptions.includeSourceProvenance]$(transformer) is set to true
     classesToIgnoreMissingEntitiesOfInTarget = [...IModelTransformer.provenanceElementClasses, ...IModelTransformer.provenanceElementAspectClasses],
     compareElemGeom = false,
+    ignoreFedGuidsOnAlwaysPresentElementIds = true,
   }: {
     expectedElemsOnlyInSource?: Partial<ElementProps>[];
     /** before checking elements that are only in the source are correct, filter out elements of these classes */
     classesToIgnoreMissingEntitiesOfInTarget?: typeof Entity[];
     compareElemGeom?: boolean;
+    /** if true, ignores the fed guids present on always present elements (present even in an empty iModel!).
+     * That list includes the root subject (0x1), dictionaryModel (0x10) and the realityDataSourcesModel (0xe) */
+    ignoreFedGuidsOnAlwaysPresentElementIds?: boolean;
   } = {}
 ) {
+  const alwaysPresentElementIds = new Set<Id64String>(["0x1", "0x10", "0xe"]);
   const [remapElem, remapCodeSpec, remapAspect]
     = remapper instanceof IModelTransformer
       ? [remapper.context.findTargetElementId.bind(remapper.context),
@@ -274,7 +279,8 @@ export async function assertIdentityTransformation(
         // known cases for the prop expecting to have been changed by the transformation under normal circumstances
         // - federation guid will be generated if it didn't exist
         // - jsonProperties may include remapped ids
-        const propChangesAllowed = sourceElem.federationGuid === undefined || propName === "jsonProperties";
+        const propChangesAllowed = ((propName === "federationGuid" && (sourceElem.federationGuid === undefined || (ignoreFedGuidsOnAlwaysPresentElementIds && alwaysPresentElementIds.has(sourceElemId))))
+        || propName === "jsonProperties");
         if (prop.isNavigation) {
           expect(sourceElem.classFullName).to.equal(targetElem.classFullName);
           // some custom handled classes make it difficult to inspect the element props directly with the metadata prop name

--- a/packages/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -1135,11 +1135,19 @@ describe("IModelTransformer", () => {
 
   /** gets a mapping of element ids to their invariant content */
   async function getAllElementsInvariants(db: IModelDb, filterPredicate?: (element: Element) => boolean) {
+    // The set of element Ids where the fed guid should be ignored (since it can change between transforms).
+    const ignoreFedGuidElementIds = new Set<Id64String>([
+      IModel.rootSubjectId,
+      IModel.dictionaryId,
+      "0xe", // id of realityDataSourcesModel
+    ]);
     const result: Record<Id64String, any> = {};
     // eslint-disable-next-line deprecation/deprecation
     for await (const row of db.query("SELECT * FROM bis.Element", undefined, { rowFormat: QueryRowFormat.UseJsPropertyNames })) {
       if (!filterPredicate || filterPredicate(db.elements.getElement(row.id))) {
         const { lastMod: _lastMod, ...invariantPortion } = row;
+        if (ignoreFedGuidElementIds.has(row.id))
+          delete invariantPortion.federationGuid;
         result[row.id] = invariantPortion;
       }
     }

--- a/packages/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -1089,7 +1089,9 @@ describe("IModelTransformer", () => {
     nativeDb.resetBriefcaseId(BriefcaseIdValue.Unassigned); // standalone iModels should always have BriefcaseId unassigned
     nativeDb.saveLocalValue("StandaloneEdit", JSON.stringify({ txns: true }));
     nativeDb.saveChanges(); // save change to briefcaseId
-    nativeDb.closeIModel();
+    // handle cross-version usage of internal API
+    (nativeDb as any)?.closeIModel();
+    (nativeDb as any)?.closeFile();
   }
 
   it("biscore update is valid", async () => {
@@ -1108,7 +1110,9 @@ describe("IModelTransformer", () => {
     // StandaloneDb.upgradeStandaloneSchemas is the suggested method to handle a profile upgrade but that will also upgrade
     // the BisCore schema.  This test is explicitly testing that the BisCore schema will be updated from the source iModel
     const nativeDb = StandaloneDb.openDgnDb({path: targetDbPath}, OpenMode.ReadWrite, {profile: ProfileOptions.Upgrade, schemaLockHeld: true});
-    nativeDb.closeIModel();
+    // handle cross-version usage of internal API
+    (nativeDb as any)?.closeIModel();
+    (nativeDb as any)?.closeFile();
     const targetDb = StandaloneDb.openFile(targetDbPath);
 
     assert(

--- a/packages/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -1090,8 +1090,8 @@ describe("IModelTransformer", () => {
     nativeDb.saveLocalValue("StandaloneEdit", JSON.stringify({ txns: true }));
     nativeDb.saveChanges(); // save change to briefcaseId
     // handle cross-version usage of internal API
-    (nativeDb as any)?.closeIModel();
-    (nativeDb as any)?.closeFile();
+    (nativeDb as any)?.closeIModel?.();
+    (nativeDb as any)?.closeFile?.();
   }
 
   it("biscore update is valid", async () => {
@@ -1111,8 +1111,8 @@ describe("IModelTransformer", () => {
     // the BisCore schema.  This test is explicitly testing that the BisCore schema will be updated from the source iModel
     const nativeDb = StandaloneDb.openDgnDb({path: targetDbPath}, OpenMode.ReadWrite, {profile: ProfileOptions.Upgrade, schemaLockHeld: true});
     // handle cross-version usage of internal API
-    (nativeDb as any)?.closeIModel();
-    (nativeDb as any)?.closeFile();
+    (nativeDb as any)?.closeIModel?.();
+    (nativeDb as any)?.closeFile?.();
     const targetDb = StandaloneDb.openFile(targetDbPath);
 
     assert(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
       typescript: ^5.0.2
     devDependencies:
       '@itwin/build-tools': 4.1.1_@types+node@18.16.14
-      '@itwin/core-backend': 4.1.1
+      '@itwin/core-backend': 4.3.3
       '@types/node': 18.16.14
       typescript: 5.1.3
 
@@ -65,16 +65,16 @@ importers:
       typescript: ^5.0.2
       yargs: ^16.0.0
     dependencies:
-      '@itwin/core-backend': 4.1.1_gbuep6d2vehqhhbd7fgq3gptdy
-      '@itwin/core-bentley': 4.1.1
-      '@itwin/core-common': 4.1.1_2dlnqk3h6wil4io5pqf6n55z2y
-      '@itwin/core-geometry': 4.1.1
-      '@itwin/core-quantity': 4.1.1_@itwin+core-bentley@4.1.1
-      '@itwin/ecschema-metadata': 4.1.1_xa7h3ubkcwg2ghrmdeixqy4vme
+      '@itwin/core-backend': 4.3.3_7qfebkgfkytmdr5gckh4dqdaey
+      '@itwin/core-bentley': 4.3.3
+      '@itwin/core-common': 4.3.3_dg7g5ezpru5bq5yk7sprirsab4
+      '@itwin/core-geometry': 4.3.3
+      '@itwin/core-quantity': 4.3.3_@itwin+core-bentley@4.3.3
+      '@itwin/ecschema-metadata': 4.3.3_sdm5gegleenbqnydb5oklqjdwi
       '@itwin/imodel-transformer': link:../transformer
-      '@itwin/imodels-access-backend': 2.3.0_u57if3ps4gurukqatctgxhghxi
+      '@itwin/imodels-access-backend': 2.3.0_5xnr4beoei3a7phgmgwcw7s27q
       '@itwin/imodels-client-authoring': 2.3.0
-      '@itwin/node-cli-authorization': 0.9.2_@itwin+core-bentley@4.1.1
+      '@itwin/node-cli-authorization': 0.9.2_@itwin+core-bentley@4.3.3
       '@itwin/perf-tools': 3.7.2
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
@@ -83,7 +83,7 @@ importers:
     devDependencies:
       '@itwin/build-tools': 4.1.1_@types+node@14.14.31
       '@itwin/eslint-plugin': 3.7.8_nydeehezxge4zglz7xgffbdlvu
-      '@itwin/oidc-signin-tool': 3.7.2_2dlnqk3h6wil4io5pqf6n55z2y
+      '@itwin/oidc-signin-tool': 3.7.2_dg7g5ezpru5bq5yk7sprirsab4
       '@itwin/projects-client': 0.6.0
       '@types/chai': 4.3.1
       '@types/fs-extra': 4.0.12
@@ -126,14 +126,14 @@ importers:
       typescript: ^5.0.2
       yargs: ^17.4.0
     dependencies:
-      '@itwin/core-backend': 4.1.1_gbuep6d2vehqhhbd7fgq3gptdy
-      '@itwin/core-bentley': 4.1.1
-      '@itwin/core-common': 4.1.1_2dlnqk3h6wil4io5pqf6n55z2y
-      '@itwin/core-geometry': 4.1.1
+      '@itwin/core-backend': 4.3.3_7qfebkgfkytmdr5gckh4dqdaey
+      '@itwin/core-bentley': 4.3.3
+      '@itwin/core-common': 4.3.3_dg7g5ezpru5bq5yk7sprirsab4
+      '@itwin/core-geometry': 4.3.3
       '@itwin/imodel-transformer': link:../transformer
-      '@itwin/imodels-access-backend': 2.3.0_u57if3ps4gurukqatctgxhghxi
+      '@itwin/imodels-access-backend': 2.3.0_5xnr4beoei3a7phgmgwcw7s27q
       '@itwin/imodels-client-authoring': 2.3.0
-      '@itwin/node-cli-authorization': 0.9.2_@itwin+core-bentley@4.1.1
+      '@itwin/node-cli-authorization': 0.9.2_@itwin+core-bentley@4.3.3
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
       fs-extra: 8.1.0
@@ -188,12 +188,12 @@ importers:
       semver: 7.5.1
     devDependencies:
       '@itwin/build-tools': 4.0.0-dev.86_@types+node@18.16.16
-      '@itwin/core-backend': 4.1.1_gbuep6d2vehqhhbd7fgq3gptdy
-      '@itwin/core-bentley': 4.1.1
-      '@itwin/core-common': 4.1.1_2dlnqk3h6wil4io5pqf6n55z2y
-      '@itwin/core-geometry': 4.1.1
-      '@itwin/core-quantity': 4.1.1_@itwin+core-bentley@4.1.1
-      '@itwin/ecschema-metadata': 4.0.2_xa7h3ubkcwg2ghrmdeixqy4vme
+      '@itwin/core-backend': 4.3.3_7qfebkgfkytmdr5gckh4dqdaey
+      '@itwin/core-bentley': 4.3.3
+      '@itwin/core-common': 4.3.3_dg7g5ezpru5bq5yk7sprirsab4
+      '@itwin/core-geometry': 4.3.3
+      '@itwin/core-quantity': 4.3.3_@itwin+core-bentley@4.3.3
+      '@itwin/ecschema-metadata': 4.3.3_sdm5gegleenbqnydb5oklqjdwi
       '@itwin/eslint-plugin': 3.7.8_nydeehezxge4zglz7xgffbdlvu
       '@types/chai': 4.3.1
       '@types/chai-as-promised': 7.1.5
@@ -236,7 +236,7 @@ packages:
     engines: {node: '>=12.0.0'}
     dependencies:
       '@azure/abort-controller': 1.1.0
-      tslib: 2.5.3
+      tslib: 2.6.1
     dev: false
 
   /@azure/core-auth/1.5.0:
@@ -328,7 +328,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@azure/abort-controller': 1.1.0
-      tslib: 2.5.3
+      tslib: 2.6.1
     dev: false
 
   /@azure/core-util/1.4.0:
@@ -604,8 +604,8 @@ packages:
       to-fast-properties: 2.0.0
     dev: true
 
-  /@bentley/imodeljs-native/4.1.9:
-    resolution: {integrity: sha512-Ym675wTR7ck6/BiAZeaiXiubgNk/N5jU1dvhldfYP+gOVoKaGT4sSqGZRxIlvB00pINytW4RI7OYDhgz1RT39A==}
+  /@bentley/imodeljs-native/4.3.6:
+    resolution: {integrity: sha512-c0DKEqyUpGOqu2NNU9IFJ96IcmIYA0eyl7rBmmeu9B4mmLW1n8ktdAPVIqd6jxbM+sdmiVwQIZOkAKk1DQpU3Q==}
     requiresBuild: true
 
   /@cspotcode/source-map-support/0.8.1:
@@ -825,21 +825,21 @@ packages:
       inversify: 6.0.1
       reflect-metadata: 0.1.13
 
-  /@itwin/core-backend/4.1.1:
-    resolution: {integrity: sha512-whSB5SfZeIsE5EPnyByd4IpLIQpIp/d7TpBDOude7yCuNOQB+MRLx3XV7JWcUBjZPmjEQSulVFsPFZkMoLu/HA==}
-    engines: {node: ^18.0.0}
+  /@itwin/core-backend/4.3.3:
+    resolution: {integrity: sha512-zhKqmnUQsgwWMbbMD17eK2gbZ39/N5hKiFLP4l5dfAZBDgk0VPHhHo4uwsh6izloT6x7Wox9RnrVGVP6n39S+A==}
+    engines: {node: ^18.0.0 || ^20.0.0}
     peerDependencies:
-      '@itwin/core-bentley': ^4.1.1
-      '@itwin/core-common': ^4.1.1
-      '@itwin/core-geometry': ^4.1.1
+      '@itwin/core-bentley': ^4.3.3
+      '@itwin/core-common': ^4.3.3
+      '@itwin/core-geometry': ^4.3.3
       '@opentelemetry/api': ^1.0.4
     peerDependenciesMeta:
       '@opentelemetry/api':
         optional: true
     dependencies:
-      '@bentley/imodeljs-native': 4.1.9
+      '@bentley/imodeljs-native': 4.3.6
       '@itwin/cloud-agnostic-core': 2.1.0_scz6qrwecfbbxg4vskopkl3a7u
-      '@itwin/core-telemetry': 4.1.1
+      '@itwin/core-telemetry': 4.3.3
       '@itwin/object-storage-azure': 2.1.0_scz6qrwecfbbxg4vskopkl3a7u
       '@itwin/object-storage-core': 2.1.0_scz6qrwecfbbxg4vskopkl3a7u
       form-data: 2.5.1
@@ -849,6 +849,7 @@ packages:
       multiparty: 4.2.3
       reflect-metadata: 0.1.13
       semver: 7.5.1
+      touch: 3.1.0
       ws: 7.5.9
     transitivePeerDependencies:
       - bufferutil
@@ -857,24 +858,24 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@itwin/core-backend/4.1.1_gbuep6d2vehqhhbd7fgq3gptdy:
-    resolution: {integrity: sha512-whSB5SfZeIsE5EPnyByd4IpLIQpIp/d7TpBDOude7yCuNOQB+MRLx3XV7JWcUBjZPmjEQSulVFsPFZkMoLu/HA==}
-    engines: {node: ^18.0.0}
+  /@itwin/core-backend/4.3.3_7qfebkgfkytmdr5gckh4dqdaey:
+    resolution: {integrity: sha512-zhKqmnUQsgwWMbbMD17eK2gbZ39/N5hKiFLP4l5dfAZBDgk0VPHhHo4uwsh6izloT6x7Wox9RnrVGVP6n39S+A==}
+    engines: {node: ^18.0.0 || ^20.0.0}
     peerDependencies:
-      '@itwin/core-bentley': ^4.1.1
-      '@itwin/core-common': ^4.1.1
-      '@itwin/core-geometry': ^4.1.1
+      '@itwin/core-bentley': ^4.3.3
+      '@itwin/core-common': ^4.3.3
+      '@itwin/core-geometry': ^4.3.3
       '@opentelemetry/api': ^1.0.4
     peerDependenciesMeta:
       '@opentelemetry/api':
         optional: true
     dependencies:
-      '@bentley/imodeljs-native': 4.1.9
+      '@bentley/imodeljs-native': 4.3.6
       '@itwin/cloud-agnostic-core': 2.1.0_scz6qrwecfbbxg4vskopkl3a7u
-      '@itwin/core-bentley': 4.1.1
-      '@itwin/core-common': 4.1.1_2dlnqk3h6wil4io5pqf6n55z2y
-      '@itwin/core-geometry': 4.1.1
-      '@itwin/core-telemetry': 4.1.1_@itwin+core-geometry@4.1.1
+      '@itwin/core-bentley': 4.3.3
+      '@itwin/core-common': 4.3.3_dg7g5ezpru5bq5yk7sprirsab4
+      '@itwin/core-geometry': 4.3.3
+      '@itwin/core-telemetry': 4.3.3_@itwin+core-geometry@4.3.3
       '@itwin/object-storage-azure': 2.1.0_scz6qrwecfbbxg4vskopkl3a7u
       '@itwin/object-storage-core': 2.1.0_scz6qrwecfbbxg4vskopkl3a7u
       form-data: 2.5.1
@@ -884,6 +885,7 @@ packages:
       multiparty: 4.2.3
       reflect-metadata: 0.1.13
       semver: 7.5.1
+      touch: 3.1.0
       ws: 7.5.9
     transitivePeerDependencies:
       - bufferutil
@@ -891,82 +893,70 @@ packages:
       - encoding
       - utf-8-validate
 
-  /@itwin/core-bentley/4.1.1:
-    resolution: {integrity: sha512-vn/3nz/Guvlji+u1ttiZ9Wy9J+FjRdEMEmoWa1zM0X+utl7CxE5TRbLEU6/yGPLtH/aFhfqhbj6YmBayiA2Fmg==}
+  /@itwin/core-bentley/4.3.3:
+    resolution: {integrity: sha512-7Fs/JFYX3T6HW5zS0YHyUX5beWiT7JHR6v9dKkPk+i27i6bdDrQaVnj+IITe+eYrIQPchOMIxrOpKRZdR5Oz2A==}
 
-  /@itwin/core-common/4.1.1_2dlnqk3h6wil4io5pqf6n55z2y:
-    resolution: {integrity: sha512-c9fh/2iQnh/ZIz2re0UFa9d/tZBEFEPnnJY1F1wupLftcFqOgkrBlVDPoYs1NUi4tQaKdbZNtvMp5ACdKmsIAw==}
+  /@itwin/core-common/4.3.3_@itwin+core-bentley@4.3.3:
+    resolution: {integrity: sha512-SwBVWtIyIMC2ww3TWGwqL24kOClT8QOHiNOpOTOSeVkDv1k12+oO4BzpAmMqwyJ/ucC0qlrBLDv+umcr1mQVwg==}
     peerDependencies:
-      '@itwin/core-bentley': ^4.1.1
-      '@itwin/core-geometry': ^4.1.1
+      '@itwin/core-bentley': ^4.3.3
+      '@itwin/core-geometry': ^4.3.3
     dependencies:
-      '@itwin/core-bentley': 4.1.1
-      '@itwin/core-geometry': 4.1.1
-      flatbuffers: 1.12.0
-      js-base64: 3.7.5
-
-  /@itwin/core-common/4.1.1_@itwin+core-bentley@4.1.1:
-    resolution: {integrity: sha512-c9fh/2iQnh/ZIz2re0UFa9d/tZBEFEPnnJY1F1wupLftcFqOgkrBlVDPoYs1NUi4tQaKdbZNtvMp5ACdKmsIAw==}
-    peerDependencies:
-      '@itwin/core-bentley': ^4.1.1
-      '@itwin/core-geometry': ^4.1.1
-    dependencies:
-      '@itwin/core-bentley': 4.1.1
+      '@itwin/core-bentley': 4.3.3
       flatbuffers: 1.12.0
       js-base64: 3.7.5
     dev: true
 
-  /@itwin/core-geometry/4.1.1:
-    resolution: {integrity: sha512-qJ898D+wftU8IBTYa3RfSQFeiplt+OF0RkDUbcA85y+GvnLvF/dmUKHvwAY7NfVL1+JDJdf3ovERqzFuBM670w==}
+  /@itwin/core-common/4.3.3_dg7g5ezpru5bq5yk7sprirsab4:
+    resolution: {integrity: sha512-SwBVWtIyIMC2ww3TWGwqL24kOClT8QOHiNOpOTOSeVkDv1k12+oO4BzpAmMqwyJ/ucC0qlrBLDv+umcr1mQVwg==}
+    peerDependencies:
+      '@itwin/core-bentley': ^4.3.3
+      '@itwin/core-geometry': ^4.3.3
     dependencies:
-      '@itwin/core-bentley': 4.1.1
+      '@itwin/core-bentley': 4.3.3
+      '@itwin/core-geometry': 4.3.3
+      flatbuffers: 1.12.0
+      js-base64: 3.7.5
+
+  /@itwin/core-geometry/4.3.3:
+    resolution: {integrity: sha512-wGUXSYnll2kJ42XoauEcdCikrll9qiHe2p3zK5vUgIrt9Edggao8t2tmLQxuz1NlxWOxoWDGNCAs665I46GM8w==}
+    dependencies:
+      '@itwin/core-bentley': 4.3.3
       flatbuffers: 1.12.0
 
-  /@itwin/core-quantity/4.1.1_@itwin+core-bentley@4.1.1:
-    resolution: {integrity: sha512-QGgitMX30K8L1xJmzVJ5GQRaBiPn3ihUTQAimz1QEHCIUa49S2UWLbe9oVf+4WREK86wfNDLF4Jadl1VB9gB1w==}
+  /@itwin/core-quantity/4.3.3_@itwin+core-bentley@4.3.3:
+    resolution: {integrity: sha512-IIq1iRFqwzwFV4oVj4UyHgwAWCze2jAipJKWnha37BQrYvwaJZP1Pt+6agzbcTaQCOnzubIQoEsxJIQymx4Xpg==}
     peerDependencies:
-      '@itwin/core-bentley': ^4.1.1
+      '@itwin/core-bentley': ^4.3.3
     dependencies:
-      '@itwin/core-bentley': 4.1.1
+      '@itwin/core-bentley': 4.3.3
 
-  /@itwin/core-telemetry/4.1.1:
-    resolution: {integrity: sha512-TGuZ6A5q12gJhMmd5R7PmNl6TAvnws5BFz70NqPGT+nbcgugZVK0iaHwmNi738XRKRsSdavoAnbNIzGgDJJ2tA==}
+  /@itwin/core-telemetry/4.3.3:
+    resolution: {integrity: sha512-M8DxiSBHdsJJjg55bE9/BbrQKug51NpUijJlQoXhOEk1fu2Op8oIRCy0dUATRFbY1mRO/NwdFqsxsBucVgq85A==}
     dependencies:
-      '@itwin/core-bentley': 4.1.1
-      '@itwin/core-common': 4.1.1_@itwin+core-bentley@4.1.1
+      '@itwin/core-bentley': 4.3.3
+      '@itwin/core-common': 4.3.3_@itwin+core-bentley@4.3.3
     transitivePeerDependencies:
       - '@itwin/core-geometry'
     dev: true
 
-  /@itwin/core-telemetry/4.1.1_@itwin+core-geometry@4.1.1:
-    resolution: {integrity: sha512-TGuZ6A5q12gJhMmd5R7PmNl6TAvnws5BFz70NqPGT+nbcgugZVK0iaHwmNi738XRKRsSdavoAnbNIzGgDJJ2tA==}
+  /@itwin/core-telemetry/4.3.3_@itwin+core-geometry@4.3.3:
+    resolution: {integrity: sha512-M8DxiSBHdsJJjg55bE9/BbrQKug51NpUijJlQoXhOEk1fu2Op8oIRCy0dUATRFbY1mRO/NwdFqsxsBucVgq85A==}
     dependencies:
-      '@itwin/core-bentley': 4.1.1
-      '@itwin/core-common': 4.1.1_2dlnqk3h6wil4io5pqf6n55z2y
+      '@itwin/core-bentley': 4.3.3
+      '@itwin/core-common': 4.3.3_dg7g5ezpru5bq5yk7sprirsab4
     transitivePeerDependencies:
       - '@itwin/core-geometry'
 
-  /@itwin/ecschema-metadata/4.0.2_xa7h3ubkcwg2ghrmdeixqy4vme:
-    resolution: {integrity: sha512-NXjY31TofOF5thxfxUUebzv0PbeiHS+rSnIgSVeowY1wWKxBT3GeiueoP2T4lBBCTOwySDnZW6nVkeQp5XepzQ==}
+  /@itwin/ecschema-metadata/4.3.3_sdm5gegleenbqnydb5oklqjdwi:
+    resolution: {integrity: sha512-rQx4mm99EahWzUC7l8hZnA1DT+D+/lOxVHxaokFdMxlVYzsyONoRmZPemJln5GkbXOQuI38zCxMCc8AFWGQVzA==}
     peerDependencies:
-      '@itwin/core-bentley': ^4.0.2
-      '@itwin/core-quantity': ^4.0.2
+      '@itwin/core-bentley': ^4.3.3
+      '@itwin/core-quantity': ^4.3.3
     dependencies:
-      '@itwin/core-bentley': 4.1.1
-      '@itwin/core-quantity': 4.1.1_@itwin+core-bentley@4.1.1
+      '@itwin/core-bentley': 4.3.3
+      '@itwin/core-quantity': 4.3.3_@itwin+core-bentley@4.3.3
       almost-equal: 1.1.0
-    dev: true
-
-  /@itwin/ecschema-metadata/4.1.1_xa7h3ubkcwg2ghrmdeixqy4vme:
-    resolution: {integrity: sha512-lt1zamZjgpqQ8N17+R4BfWtNNZyCArZgmS26wJDl36bSIqz0BWD1tH4foeoagr7alkjE233UMjoTJivHfK0Dgw==}
-    peerDependencies:
-      '@itwin/core-bentley': ^4.1.1
-      '@itwin/core-quantity': ^4.1.1
-    dependencies:
-      '@itwin/core-bentley': 4.1.1
-      '@itwin/core-quantity': 4.1.1_@itwin+core-bentley@4.1.1
-      almost-equal: 1.1.0
-    dev: false
 
   /@itwin/eslint-plugin/3.7.8_nydeehezxge4zglz7xgffbdlvu:
     resolution: {integrity: sha512-zPgGUZro3NZNH5CVCrzxy+Zyi0CucCMO3aYsPn8eaAvLQE1iqWt+M0XT+ih6FwZXRiHSrPhNrjTvP8cuFC96og==}
@@ -995,7 +985,7 @@ packages:
       - supports-color
     dev: true
 
-  /@itwin/imodels-access-backend/2.3.0_u57if3ps4gurukqatctgxhghxi:
+  /@itwin/imodels-access-backend/2.3.0_5xnr4beoei3a7phgmgwcw7s27q:
     resolution: {integrity: sha512-g2Bygiu6Is/Xa6OWUxXN/BZwGU2M4izFl8fdgL1cFWxhoWSYL169bN3V4zvRTUJIqtsNaTyOeRu2mjkRgHY9KQ==}
     peerDependencies:
       '@itwin/core-backend': ^3.3.0
@@ -1003,9 +993,9 @@ packages:
       '@itwin/core-common': ^3.3.0
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@itwin/core-backend': 4.1.1_gbuep6d2vehqhhbd7fgq3gptdy
-      '@itwin/core-bentley': 4.1.1
-      '@itwin/core-common': 4.1.1_2dlnqk3h6wil4io5pqf6n55z2y
+      '@itwin/core-backend': 4.3.3_7qfebkgfkytmdr5gckh4dqdaey
+      '@itwin/core-bentley': 4.3.3
+      '@itwin/core-common': 4.3.3_dg7g5ezpru5bq5yk7sprirsab4
       '@itwin/imodels-client-authoring': 2.3.0
       axios: 0.21.4
     transitivePeerDependencies:
@@ -1033,12 +1023,12 @@ packages:
       - debug
     dev: false
 
-  /@itwin/node-cli-authorization/0.9.2_@itwin+core-bentley@4.1.1:
+  /@itwin/node-cli-authorization/0.9.2_@itwin+core-bentley@4.3.3:
     resolution: {integrity: sha512-/L1MYQEKlwfBaHhO1OgRvxFOcq77lUyjR1JSeyl9iYLWuxYdwrjuRTObgX/XCGogRm3ZcUHR9YctRJgPrRyjwg==}
     peerDependencies:
       '@itwin/core-bentley': ^3.0.0
     dependencies:
-      '@itwin/core-bentley': 4.1.1
+      '@itwin/core-bentley': 4.3.3
       '@openid/appauth': 1.3.1
       keytar: 7.9.0
       open: 8.4.2
@@ -1105,15 +1095,15 @@ packages:
     transitivePeerDependencies:
       - debug
 
-  /@itwin/oidc-signin-tool/3.7.2_2dlnqk3h6wil4io5pqf6n55z2y:
+  /@itwin/oidc-signin-tool/3.7.2_dg7g5ezpru5bq5yk7sprirsab4:
     resolution: {integrity: sha512-DA5uWjGKFWP+ISySlLYXsTCHTogJn4O+z+R/XNmcR/8jiRiFMGr3aYmjklgrvUmYDJyl8llxSnVMz9w115+D1w==}
     requiresBuild: true
     peerDependencies:
       '@itwin/core-bentley': '>=3.3.0'
     dependencies:
       '@itwin/certa': 3.7.8
-      '@itwin/core-bentley': 4.1.1
-      '@itwin/core-common': 4.1.1_2dlnqk3h6wil4io5pqf6n55z2y
+      '@itwin/core-bentley': 4.3.3
+      '@itwin/core-common': 4.3.3_dg7g5ezpru5bq5yk7sprirsab4
       '@playwright/test': 1.31.2
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
@@ -1595,8 +1585,8 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@types/yauzl/2.10.0:
-    resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
+  /@types/yauzl/2.10.3:
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
     requiresBuild: true
     dependencies:
       '@types/node': 18.16.16
@@ -1840,6 +1830,9 @@ packages:
   /@yarnpkg/lockfile/1.1.0:
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
     dev: true
+
+  /abbrev/1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
 
   /accepts/1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -2355,7 +2348,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /chownr/1.1.4:
@@ -3377,7 +3370,7 @@ packages:
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
-      '@types/yauzl': 2.10.0
+      '@types/yauzl': 2.10.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3597,6 +3590,14 @@ packages:
     dev: true
     optional: true
 
+  /fsevents/2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /function-bind/1.1.1:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
     dev: true
@@ -3687,7 +3688,7 @@ packages:
     dev: true
 
   /github-from-package/0.0.0:
-    resolution: {integrity: sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=}
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
     dev: false
 
   /glob-parent/5.1.2:
@@ -4887,6 +4888,12 @@ packages:
     resolution: {integrity: sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==}
     dev: true
 
+  /nopt/1.0.10:
+    resolution: {integrity: sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==}
+    hasBin: true
+    dependencies:
+      abbrev: 1.1.1
+
   /normalize-package-data/2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
     dependencies:
@@ -5667,7 +5674,7 @@ packages:
   /rxjs/7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.1
     dev: true
 
   /safe-buffer/5.2.1:
@@ -6147,6 +6154,12 @@ packages:
   /toposort/2.0.2:
     resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
     dev: true
+
+  /touch/3.1.0:
+    resolution: {integrity: sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==}
+    hasBin: true
+    dependencies:
+      nopt: 1.0.10
 
   /tough-cookie/4.1.3:
     resolution: {integrity: sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==}

--- a/scripts/update_deps.sh
+++ b/scripts/update_deps.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# upgrade all itwin dependencies
+pnpm dlx pnpm@7 -r update $( git ls-files '*package.json' | xargs -i jq '.dependencies|keys[]' {} | grep itwin | sed 's/"//g')
+git stash push '*package.json'
+# reinstall old package.json on new updated dev deps
+pnpm dlx pnpm@7 install


### PR DESCRIPTION
- Ignore fed guids on always present element ids when comparing imodels in tests
- closeIModel() + closeFile()
- script to only update locked itwin deps
- bump locked itwin dev deps