### PR TITLE
Implemented missing methods in BigMap 

### DIFF
--- a/change/@itwin-imodel-transformer-e3cb3820-f8ac-4f7b-bb7d-8f41018c5ecf.json
+++ b/change/@itwin-imodel-transformer-e3cb3820-f8ac-4f7b-bb7d-8f41018c5ecf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed BigMap class to implement Map (instead of extending it). Added missing method implementations.",
+  "packageName": "@itwin/imodel-transformer",
+  "email": "Julija.Ramoskiene@bentley.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/transformer/src/test/standalone/BigMap.test.ts
+++ b/packages/transformer/src/test/standalone/BigMap.test.ts
@@ -1,0 +1,84 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { BigMap } from "../../BigMap";
+import { assert } from "chai";
+
+describe("BigMap", function () {
+
+  // Test map keys will be assigned into 2 different submaps when BigMap is created
+  const testMap = new Map ([["0x123f", "testVal1"], ["0x1231", "testVal2"]]);
+
+  const createBigMap = (map: Map<string, string>): BigMap<string> => {
+    const bigMap = new BigMap <string> ();
+    for (const entry of map.entries ()) {
+      bigMap.set(entry[0], entry[1]);
+    }
+    return bigMap;
+  };
+
+  describe("keys", function () {
+    it("should iterate all keys", async function () {
+      const bigMap = createBigMap (testMap);
+      assert.sameMembers([...bigMap.keys()], [...testMap.keys()]);
+    });
+  });
+
+  describe("values", function () {
+    it("should get all values", async function () {
+      const bigMap = createBigMap (testMap);
+      assert.sameMembers([...bigMap.values()], [...testMap.values()]);
+    });
+  });
+
+  describe("entries", function () {
+    it("should get all values", async function () {
+      const bigMap = createBigMap (testMap);
+      const actualMap  = new Map([...bigMap.entries()]);
+      assert.deepEqual(actualMap, testMap);
+    });
+  });
+
+  describe("iterator", function () {
+    it("should get all values", async function () {
+      const bigMap = createBigMap (testMap);
+
+      const actualMap  = new Map();
+      for (const entry of bigMap) {
+        actualMap.set(entry[0], entry[1]);
+      }
+      assert.deepEqual(actualMap, testMap);
+    });
+  });
+
+  describe("toStringTag", function () {
+    it("should return type name", async function () {
+      const typeName = Object.prototype.toString.call(new BigMap <string> ());
+      assert.equal(typeName, "[object BigMap]");
+    });
+  });
+
+  describe("has", function () {
+    it("should return true when value was set", async function () {
+      const bigMap = new BigMap <string> ();
+      const key = "0x123f";
+      bigMap.set(key, "12134");
+      assert.isTrue (bigMap.has(key));
+    });
+  });
+
+  describe("set", function () {
+    it("should set when key has submap", async function () {
+      const bigMap = new BigMap <string> ();
+      assert.doesNotThrow(() => bigMap.set("0x13", "12134"));
+      assert.equal(bigMap.size, 1);
+    });
+
+    it("should throw when key has no submap", async function () {
+      const bigMap = new BigMap <string> ();
+      assert.throw(() => bigMap.set("g", "12134"), "Tried to set g, but that key has no submap");
+    });
+  });
+});

--- a/packages/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -19,7 +19,7 @@ import {
 import * as coreBackendPkgJson from "@itwin/core-backend/package.json";
 import * as ECSchemaMetaData from "@itwin/ecschema-metadata";
 import * as TestUtils from "../TestUtils";
-import { DbResult, Guid, Id64, Id64String, Logger, LogLevel, OpenMode } from "@itwin/core-bentley";
+import { DbResult, Guid, Id64, Id64String, Logger, LoggingMetaData, LogLevel, OpenMode } from "@itwin/core-bentley";
 import {
   AxisAlignedBox3d, BriefcaseIdValue, Code, CodeScopeSpec, CodeSpec, ColorDef, CreateIModelProps, DefinitionElementProps, ElementAspectProps, ElementProps,
   ExternalSourceAspectProps, GeometricElement2dProps, ImageSourceFormat, IModel, IModelError, InformationPartitionElementProps, ModelProps, PhysicalElementProps, Placement3d, ProfileOptions, QueryRowFormat, RelatedElement, RelationshipProps, RepositoryLinkProps,
@@ -71,6 +71,9 @@ describe("IModelTransformer", () => {
     if (!IModelJsFs.existsSync(outputDir)) {
       IModelJsFs.mkdirSync(outputDir);
     }
+  });
+
+  beforeEach(async () => {
     // initialize logging
     if (process.env.LOG_TRANSFORMER_IN_TESTS) {
       Logger.initializeToConsole();
@@ -639,6 +642,55 @@ describe("IModelTransformer", () => {
     }
 
     IModelTransformerTestUtils.dumpIModelInfo(iModelShared);
+    iModelShared.close();
+  });
+
+  it("should log unresolved references", async () => {
+    const iModelShared: SnapshotDb = IModelTransformerTestUtils.createSharedIModel(outputDir, ["A", "B"]);
+    const iModelA: SnapshotDb = IModelTransformerTestUtils.createTeamIModel(outputDir, "A", Point3d.create(0, 0, 0), ColorDef.green);
+    IModelTransformerTestUtils.assertTeamIModelContents(iModelA, "A");
+    const iModelExporterA = new IModelExporter(iModelA);
+
+    // Exclude element
+    const excludedId = iModelA.elements.queryElementIdByCode(Subject.createCode(iModelA, IModel.rootSubjectId, "Context"));
+    assert.isDefined (excludedId);
+    iModelExporterA.excludeElement(excludedId!);
+
+    const subjectId: Id64String = IModelTransformerTestUtils.querySubjectId(iModelShared, "A");
+    const transformerA2S = new IModelTransformer(iModelExporterA, iModelShared, { targetScopeElementId: subjectId });
+    transformerA2S.context.remapElement(IModel.rootSubjectId, subjectId);
+
+    // Configure logger to capture warning message about unresolved references
+    const messageStart = "The following elements were never fully resolved:\n";
+    const messageEnd = "\nThis indicates that either some references were excluded from the transformation\nor the source has dangling references.";
+
+    let unresolvedElementMessage: string | undefined;
+    const logWarning = (_category: string, message: string, _metaData: LoggingMetaData) => {
+      if (message.startsWith (messageStart)) {
+        unresolvedElementMessage = message;
+      }
+    };
+    Logger.initialize(undefined, logWarning);
+    Logger.setLevelDefault(LogLevel.Warning);
+
+    // Act
+    await transformerA2S.processAll();
+
+    // Collect expected ids
+    const result = iModelA.queryEntityIds({ from: "BisCore.Element",
+      where: "Model.Id = :rootId AND ECInstanceId NOT IN (:rootId, :excludedId)",
+      bindings: {rootId: IModel.rootSubjectId, excludedId } });
+    const expectedIds = [...result].map ((x) => `e${x}`);
+
+    // Collect actual ids
+    assert.isDefined(unresolvedElementMessage);
+    const actualIds = unresolvedElementMessage!.split(messageStart)[1].split(messageEnd)[0].split(",");
+
+    // Assert
+    assert.sameMembers(actualIds, expectedIds);
+
+    transformerA2S.dispose();
+    iModelA.close();
     iModelShared.close();
   });
 

--- a/packages/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -687,6 +687,7 @@ describe("IModelTransformer", () => {
     const actualIds = unresolvedElementMessage!.split(messageStart)[1].split(messageEnd)[0].split(",");
 
     // Assert
+    assert.equal(actualIds.length, 4);
     assert.sameMembers(actualIds, expectedIds);
 
     transformerA2S.dispose();


### PR DESCRIPTION
Closes https://github.com/iTwin/imodel-transformer/issues/134
- Changed BigMap to implement Map instead of extending it. Implemented missing methods.
- Added BigMap tests.
- Added iModelTransformer test to verify that unresolved references are logged correctly. Moved logger initialization logic to beforeEach(), as it is reconfigured in new test case.