### PR TITLE
Support running the old transformer in timelinetestutil

### DIFF
--- a/packages/old-transformer-hack/README.md
+++ b/packages/old-transformer-hack/README.md
@@ -1,0 +1,14 @@
+# old-transformer-hack
+
+## Description
+
+This package exists solely for testing the @itwin/imodel-transformer. It reexports an older version of the iModelTransformer (currently 0.4.4-dev.0) so that iModels can be tested in the transition from old transformer to new transformer (^1.x). 
+
+See packages\transformer\src\test\TestUtils\TimelineTestUtil.ts for its use.
+
+
+`import { IModelTransformer as OldIModelTransformer } from "old-transformer-hack"`;
+
+## Notes
+
+Currently both the old transformer and new transformer work with the same versions of @itwin/core-backend package. This may no longer be true in the future and may require additional changes to support having two versions of the transformer with different versions of itwinjs.

--- a/packages/old-transformer-hack/package.json
+++ b/packages/old-transformer-hack/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "old-transformer-hack",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Used to test that behavior of the old transformer is properly transitioned over to the new transformer's behavior",
+  "main": "lib/cjs/oldTransformer.js",
+  "typings": "lib/cjs/oldTransformer",
+  "scripts": {
+    "build": "npm run -s build:cjs && npm run -s copy:test-assets",
+    "build:ci": "npm run -s build",
+    "build:cjs": "tsc 1>&2 --outDir lib/cjs",
+    "clean": "rimraf lib",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "copy:test-assets": "cpx \"./src/test/assets/**/*\" ./lib/cjs/test/assets"
+  },
+  "devDependencies": {
+    "@itwin/imodel-transformer": "0.4.4-dev.0",
+    "@itwin/build-tools": "^4.3.3",
+    "@itwin/core-backend": "^4.3.3",
+    "@itwin/core-bentley": "^4.3.3",
+    "@itwin/core-common": "^4.3.3",
+    "@itwin/core-geometry": "^4.3.3",
+    "@itwin/core-quantity": "^4.3.3",
+    "@itwin/ecschema-metadata": "^4.3.3",
+    "cpx2": "^3.0.2",
+    "typescript": "^5.0.4"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/packages/old-transformer-hack/src/oldTransformer.ts
+++ b/packages/old-transformer-hack/src/oldTransformer.ts
@@ -1,0 +1,5 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+export { IModelTransformer } from "@itwin/imodel-transformer";

--- a/packages/old-transformer-hack/tsconfig.json
+++ b/packages/old-transformer-hack/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./node_modules/@itwin/build-tools/tsconfig-base.json",
+    "compilerOptions": {
+      "resolveJsonModule": true,
+      "rootDir": "src"
+    },
+    "include": ["./src/**/*.ts"]
+  }
+  

--- a/packages/transformer/package.json
+++ b/packages/transformer/package.json
@@ -74,6 +74,7 @@
     "@itwin/core-quantity": "^4.3.3",
     "@itwin/ecschema-metadata": "^4.3.3",
     "@itwin/eslint-plugin": "4.0.0-dev.48",
+    "old-transformer-hack": "workspace:*",
     "@types/chai": "4.3.1",
     "@types/chai-as-promised": "^7.1.5",
     "@types/mocha": "^8.2.3",

--- a/packages/transformer/src/test/TestUtils/TimelineTestUtil.ts
+++ b/packages/transformer/src/test/TestUtils/TimelineTestUtil.ts
@@ -31,6 +31,7 @@ import {
 } from "../IModelTransformerUtils";
 import { IModelTestUtils } from "./IModelTestUtils";
 import { omit } from "@itwin/core-bentley";
+import { IModelTransformer as OldIModelTransformer } from "old-transformer-hack";
 
 const { saveAndPushChanges } = IModelTestUtils;
 
@@ -247,6 +248,7 @@ export type TimelineStateChange =
         opts?: {
           since?: number;
           initTransformer?: (transformer: IModelTransformer) => void;
+          useOldTransformer?: boolean;
         },
       ];
     }
@@ -347,6 +349,7 @@ export async function runTimeline(
           opts: {
             since?: number;
             initTransformer?: (transformer: IModelTransformer) => void;
+            useOldTransformer?: boolean;
           },
         ]
       | undefined;
@@ -479,8 +482,10 @@ export async function runTimeline(
         // "branch" and "seed" event has already been handled in the new imodels loop above
         continue;
       } else if ("sync" in event) {
-        const [syncSource, { since: startIndex, initTransformer }] =
-          getSync(event)!;
+        const [
+          syncSource,
+          { useOldTransformer, since: startIndex, initTransformer },
+        ] = getSync(event)!;
         // if the synchronization source is master, it's a normal sync
         const isForwardSync = masterOfBranch.get(iModelName) === syncSource;
         const target = trackedIModels.get(iModelName)!;
@@ -490,11 +495,16 @@ export async function runTimeline(
         if (process.env.TRANSFORMER_BRANCH_TEST_DEBUG)
           targetStateBefore = getIModelState(target.db);
 
-        const syncer = new IModelTransformer(source.db, target.db, {
-          ...transformerOpts,
-          isReverseSynchronization: !isForwardSync,
-        });
-        initTransformer?.(syncer);
+        const syncer = useOldTransformer
+          ? new OldIModelTransformer(source.db, target.db, {
+              ...transformerOpts,
+              isReverseSynchronization: !isForwardSync,
+            })
+          : new IModelTransformer(source.db, target.db, {
+              ...transformerOpts,
+              isReverseSynchronization: !isForwardSync,
+            });
+        if (!useOldTransformer) initTransformer?.(syncer as any);
         try {
           await syncer.processChanges({
             accessToken,

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,4 +3,4 @@ packages:
   - packages/test-app
   - packages/performance-scripts
   - packages/performance-tests
-
+  - packages/old-transformer-hack


### PR DESCRIPTION
Also includes a test that I was working on with regards to old versioning behavior. Not sure its actually useful but I added it as a separate commit so we can easily revert it.