### PR TITLE
Special case root subject remapping 

### DIFF
--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -1516,17 +1516,17 @@ export class IModelTransformer extends IModelExportHandler {
       const targetElementId: string = this.context.findTargetElementId(
         sourceElement.id
       );
-      const targetElement = this.targetDb.elements.getElement(targetElementId);
-      // If target element's parent is the root subject, set code scope to be root subject id
-      // This is the case where a root subject in source is remapping to a non-root subject with root subject parent in target
-      if (targetElement.parent?.id === IModel.rootSubjectId) {
-        targetElementProps.code.scope = IModel.rootSubjectId;
-      } else if (targetElement.parent !== undefined) {
-        // If target element's parent is not the root subject, make sure that:
-        // 1. the cloned element's parent is the same as the original target element's parent
-        // 2. the cloned element's code scope is the same as the original target element's code scope
-        // This is the case where a root subject in source is remapping to a non-root subject with non-root subject parent in target
-        targetElementProps.parent = targetElement.parent;
+      // When remapping rootSubject from source to non root subject in target, the code.scope gets remapped incorrectly.
+      // This is because the rootSubject has no parent and its code.scope is unique in that it is the id of itself.
+      // For all other subjects which do have parents the code.scope and its parent should be in agreement.
+      if (
+        targetElementId !== Id64.invalid &&
+        targetElementId !== IModel.rootSubjectId
+      ) {
+        const targetElement =
+          this.targetDb.elements.getElement(targetElementId);
+        targetElementProps.parent =
+          targetElement.parent ?? targetElementProps.parent;
         targetElementProps.code.scope = targetElement.code.scope;
       }
     }

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -1511,6 +1511,25 @@ export class IModelTransformer extends IModelExportHandler {
       sourceElement,
       { binaryGeometry: this._options.cloneUsingBinaryGeometry }
     );
+    // Special case: source element is the root subject
+    if (sourceElement.id === IModel.rootSubjectId) {
+      const targetElementId: string = this.context.findTargetElementId(
+        sourceElement.id
+      );
+      const targetElement = this.targetDb.elements.getElement(targetElementId);
+      // If target element's parent is the root subject, set code scope to be root subject id
+      // This is the case where a root subject in source is remapping to a non-root subject with root subject parent in target
+      if (targetElement.parent?.id === IModel.rootSubjectId) {
+        targetElementProps.code.scope = IModel.rootSubjectId;
+      } else if (targetElement.parent !== undefined) {
+        // If target element's parent is not the root subject, make sure that:
+        // 1. the cloned element's parent is the same as the original target element's parent
+        // 2. the cloned element's code scope is the same as the original target element's code scope
+        // This is the case where a root subject in source is remapping to a non-root subject with non-root subject parent in target
+        targetElementProps.parent = targetElement.parent;
+        targetElementProps.code.scope = targetElement.code.scope;
+      }
+    }
     if (sourceElement instanceof Subject) {
       if (targetElementProps.jsonProperties?.Subject?.Job) {
         // don't propagate source channels into target (legacy bridge case)

--- a/packages/transformer/src/test/IModelTransformerUtils.ts
+++ b/packages/transformer/src/test/IModelTransformerUtils.ts
@@ -115,14 +115,15 @@ export class IModelTransformerTestUtils extends TestUtils.IModelTestUtils {
     outputDir: string,
     teamName: string,
     teamOrigin: Point3d,
-    teamColor: ColorDef
+    teamColor: ColorDef,
+    teamDescription?: string
   ): SnapshotDb {
     const teamFile: string = path.join(outputDir, `Team${teamName}.bim`);
     if (IModelJsFs.existsSync(teamFile)) {
       IModelJsFs.removeSync(teamFile);
     }
     const iModelDb: SnapshotDb = SnapshotDb.createEmpty(teamFile, {
-      rootSubject: { name: teamName },
+      rootSubject: { name: teamName, description: teamDescription },
       createClassViews: true,
     });
     assert.exists(iModelDb);
@@ -217,7 +218,8 @@ export class IModelTransformerTestUtils extends TestUtils.IModelTestUtils {
 
   public static createSharedIModel(
     outputDir: string,
-    teamNames: string[]
+    teamNames: string[],
+    iModelDescription?: string
   ): SnapshotDb {
     const iModelName: string = `Shared${teamNames.join("")}`;
     const iModelFile: string = path.join(outputDir, `${iModelName}.bim`);
@@ -225,7 +227,7 @@ export class IModelTransformerTestUtils extends TestUtils.IModelTestUtils {
       IModelJsFs.removeSync(iModelFile);
     }
     const iModelDb: SnapshotDb = SnapshotDb.createEmpty(iModelFile, {
-      rootSubject: { name: iModelName },
+      rootSubject: { name: iModelName, description: iModelDescription },
     });
     assert.exists(iModelDb);
     teamNames.forEach((teamName: string) => {

--- a/packages/transformer/src/test/IModelTransformerUtils.ts
+++ b/packages/transformer/src/test/IModelTransformerUtils.ts
@@ -116,14 +116,14 @@ export class IModelTransformerTestUtils extends TestUtils.IModelTestUtils {
     teamName: string,
     teamOrigin: Point3d,
     teamColor: ColorDef,
-    teamDescription?: string
+    rootSubjectDescription?: string
   ): SnapshotDb {
     const teamFile: string = path.join(outputDir, `Team${teamName}.bim`);
     if (IModelJsFs.existsSync(teamFile)) {
       IModelJsFs.removeSync(teamFile);
     }
     const iModelDb: SnapshotDb = SnapshotDb.createEmpty(teamFile, {
-      rootSubject: { name: teamName, description: teamDescription },
+      rootSubject: { name: teamName, description: rootSubjectDescription },
       createClassViews: true,
     });
     assert.exists(iModelDb);
@@ -219,7 +219,7 @@ export class IModelTransformerTestUtils extends TestUtils.IModelTestUtils {
   public static createSharedIModel(
     outputDir: string,
     teamNames: string[],
-    iModelDescription?: string
+    rootSubjectDescription?: string
   ): SnapshotDb {
     const iModelName: string = `Shared${teamNames.join("")}`;
     const iModelFile: string = path.join(outputDir, `${iModelName}.bim`);
@@ -227,7 +227,7 @@ export class IModelTransformerTestUtils extends TestUtils.IModelTestUtils {
       IModelJsFs.removeSync(iModelFile);
     }
     const iModelDb: SnapshotDb = SnapshotDb.createEmpty(iModelFile, {
-      rootSubject: { name: iModelName, description: iModelDescription },
+      rootSubject: { name: iModelName, description: rootSubjectDescription },
     });
     assert.exists(iModelDb);
     teamNames.forEach((teamName: string) => {

--- a/packages/transformer/src/test/TestUtils/IModelTestUtils.ts
+++ b/packages/transformer/src/test/TestUtils/IModelTestUtils.ts
@@ -541,9 +541,7 @@ export class IModelTestUtils {
     if (!IModelJsFs.existsSync(outputDir)) IModelJsFs.mkdirSync(outputDir);
 
     const outputFile = path.join(outputDir, fileName);
-    if (IModelJsFs.existsSync(outputFile)) {
-      IModelJsFs.unlinkSync(outputFile);
-    }
+    if (IModelJsFs.existsSync(outputFile)) IModelJsFs.unlinkSync(outputFile);
 
     return outputFile;
   }

--- a/packages/transformer/src/test/TestUtils/IModelTestUtils.ts
+++ b/packages/transformer/src/test/TestUtils/IModelTestUtils.ts
@@ -541,7 +541,9 @@ export class IModelTestUtils {
     if (!IModelJsFs.existsSync(outputDir)) IModelJsFs.mkdirSync(outputDir);
 
     const outputFile = path.join(outputDir, fileName);
-    if (IModelJsFs.existsSync(outputFile)) IModelJsFs.unlinkSync(outputFile);
+    if (IModelJsFs.existsSync(outputFile)) {
+      IModelJsFs.unlinkSync(outputFile);
+    }
 
     return outputFile;
   }

--- a/packages/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -1197,9 +1197,7 @@ describe("IModelTransformer", () => {
     expect(targetIModelSubject).to.have.property("parent").that.is.undefined;
     // the scope on its code is still itself.
     expect(targetIModelSubject.code.scope).to.eq(IModel.rootSubjectId);
-    IModelTransformerTestUtils.dumpIModelInfo(sourceIModelDb);
     sourceIModelDb.close();
-    IModelTransformerTestUtils.dumpIModelInfo(targetIModelDb);
     targetIModelDb.close();
   });
 
@@ -1214,12 +1212,20 @@ describe("IModelTransformer", () => {
       outputDir,
       `${targetIModelName}.bim`
     );
-    if (IModelJsFs.existsSync(sourceIModelFile)) {
-      IModelJsFs.removeSync(sourceIModelFile);
-    }
-    if (IModelJsFs.existsSync(targetIModelFile)) {
-      IModelJsFs.removeSync(targetIModelFile);
-    }
+    // if (IModelJsFs.existsSync(sourceIModelFile)) {
+    //   IModelJsFs.removeSync(sourceIModelFile);
+    // }
+    IModelTransformerTestUtils.prepareOutputFile(
+      "IModelTransformer",
+      sourceIModelFile
+    );
+    IModelTransformerTestUtils.prepareOutputFile(
+      "IModelTransformer",
+      targetIModelFile
+    );
+    // if (IModelJsFs.existsSync(targetIModelFile)) {
+    //   IModelJsFs.removeSync(targetIModelFile);
+    // }
     const sourceIModelDb: SnapshotDb = SnapshotDb.createEmpty(
       sourceIModelFile,
       {
@@ -1264,9 +1270,7 @@ describe("IModelTransformer", () => {
     // Remapping a non root-subject to a non root-subject keeps its parent and code as expected
     expect(sourceIModelSubject.parent).to.deep.eq(targetIModelSubject.parent);
     expect(sourceIModelSubject.code).to.deep.eq(targetIModelSubject.code);
-    IModelTransformerTestUtils.dumpIModelInfo(sourceIModelDb);
     sourceIModelDb.close();
-    IModelTransformerTestUtils.dumpIModelInfo(targetIModelDb);
     targetIModelDb.close();
   });
 
@@ -1318,9 +1322,7 @@ describe("IModelTransformer", () => {
       targetIModelDb.elements.getElement<Subject>(targetSubjectId);
     expect(targetIModelSubject.parent?.id).eq(IModel.rootSubjectId);
     expect(targetIModelSubject.code.scope).eq(IModel.rootSubjectId);
-    IModelTransformerTestUtils.dumpIModelInfo(sourceIModelDb);
     sourceIModelDb.close();
-    IModelTransformerTestUtils.dumpIModelInfo(targetIModelDb);
     targetIModelDb.close();
   });
 
@@ -1382,9 +1384,7 @@ describe("IModelTransformer", () => {
     expect(targetChildIModelSubject.parent?.id).eq(targetParentSubjectId);
     // child's code scope should still be its parent after remapping
     expect(targetChildIModelSubject.code.scope).eq(targetParentSubjectId);
-    IModelTransformerTestUtils.dumpIModelInfo(sourceIModelDb);
     sourceIModelDb.close();
-    IModelTransformerTestUtils.dumpIModelInfo(targetIModelDb);
     targetIModelDb.close();
   });
 

--- a/packages/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -1147,18 +1147,16 @@ describe("IModelTransformer", () => {
   });
 
   it("remap root subject to root subject", async () => {
-    const sourceIModelName: string = "source.bim";
-    const targetIModelName: string = "target.bim";
-    const sourceIModelFile: string = path.join(outputDir, sourceIModelName);
-    const targetIModelFile: string = path.join(outputDir, targetIModelName);
-    IModelTransformerTestUtils.prepareOutputFile(
-      "IModelTransformer",
-      sourceIModelName
-    );
-    IModelTransformerTestUtils.prepareOutputFile(
-      "IModelTransformer",
-      targetIModelName
-    );
+    const sourceIModelFile: string =
+      IModelTransformerTestUtils.prepareOutputFile(
+        "IModelTransformer",
+        "source.bim"
+      );
+    const targetIModelFile: string =
+      IModelTransformerTestUtils.prepareOutputFile(
+        "IModelTransformer",
+        "target.bim"
+      );
     const sourceIModelDb: SnapshotDb = SnapshotDb.createEmpty(
       sourceIModelFile,
       {
@@ -1198,18 +1196,16 @@ describe("IModelTransformer", () => {
   });
 
   it("remap non-root subject to non-root subject", async () => {
-    const sourceIModelName: string = "source.bim";
-    const targetIModelName: string = "target.bim";
-    const sourceIModelFile: string = path.join(outputDir, sourceIModelName);
-    const targetIModelFile: string = path.join(outputDir, targetIModelName);
-    IModelTransformerTestUtils.prepareOutputFile(
-      "IModelTransformer",
-      sourceIModelName
-    );
-    IModelTransformerTestUtils.prepareOutputFile(
-      "IModelTransformer",
-      targetIModelName
-    );
+    const sourceIModelFile: string =
+      IModelTransformerTestUtils.prepareOutputFile(
+        "IModelTransformer",
+        "source.bim"
+      );
+    const targetIModelFile: string =
+      IModelTransformerTestUtils.prepareOutputFile(
+        "IModelTransformer",
+        "target.bim"
+      );
     const sourceIModelDb: SnapshotDb = SnapshotDb.createEmpty(
       sourceIModelFile,
       {
@@ -1259,18 +1255,16 @@ describe("IModelTransformer", () => {
   });
 
   it("remap root subject to non-root subject", async () => {
-    const sourceIModelName: string = "source.bim";
-    const targetIModelName: string = "target.bim";
-    const sourceIModelFile: string = path.join(outputDir, sourceIModelName);
-    const targetIModelFile: string = path.join(outputDir, targetIModelName);
-    IModelTransformerTestUtils.prepareOutputFile(
-      "IModelTransformer",
-      sourceIModelName
-    );
-    IModelTransformerTestUtils.prepareOutputFile(
-      "IModelTransformer",
-      targetIModelName
-    );
+    const sourceIModelFile: string =
+      IModelTransformerTestUtils.prepareOutputFile(
+        "IModelTransformer",
+        "source.bim"
+      );
+    const targetIModelFile: string =
+      IModelTransformerTestUtils.prepareOutputFile(
+        "IModelTransformer",
+        "target.bim"
+      );
     const sourceIModelDb: SnapshotDb = SnapshotDb.createEmpty(
       sourceIModelFile,
       {
@@ -1307,18 +1301,16 @@ describe("IModelTransformer", () => {
   });
 
   it("remap root subject to non-root subject with non-root parent", async () => {
-    const sourceIModelName: string = "source.bim";
-    const targetIModelName: string = "target.bim";
-    const sourceIModelFile: string = path.join(outputDir, sourceIModelName);
-    const targetIModelFile: string = path.join(outputDir, targetIModelName);
-    IModelTransformerTestUtils.prepareOutputFile(
-      "IModelTransformer",
-      sourceIModelName
-    );
-    IModelTransformerTestUtils.prepareOutputFile(
-      "IModelTransformer",
-      targetIModelName
-    );
+    const sourceIModelFile: string =
+      IModelTransformerTestUtils.prepareOutputFile(
+        "IModelTransformer",
+        "source.bim"
+      );
+    const targetIModelFile: string =
+      IModelTransformerTestUtils.prepareOutputFile(
+        "IModelTransformer",
+        "target.bim"
+      );
     const sourceIModelDb: SnapshotDb = SnapshotDb.createEmpty(
       sourceIModelFile,
       {

--- a/packages/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -1147,22 +1147,18 @@ describe("IModelTransformer", () => {
   });
 
   it("remap root subject to root subject", async () => {
-    const sourceIModelName: string = "source";
-    const targetIModelName: string = "target";
-    const sourceIModelFile: string = path.join(
-      outputDir,
-      `${sourceIModelName}.bim`
+    const sourceIModelName: string = "source.bim";
+    const targetIModelName: string = "target.bim";
+    const sourceIModelFile: string = path.join(outputDir, sourceIModelName);
+    const targetIModelFile: string = path.join(outputDir, targetIModelName);
+    IModelTransformerTestUtils.prepareOutputFile(
+      "IModelTransformer",
+      sourceIModelName
     );
-    const targetIModelFile: string = path.join(
-      outputDir,
-      `${targetIModelName}.bim`
+    IModelTransformerTestUtils.prepareOutputFile(
+      "IModelTransformer",
+      targetIModelName
     );
-    if (IModelJsFs.existsSync(sourceIModelFile)) {
-      IModelJsFs.removeSync(sourceIModelFile);
-    }
-    if (IModelJsFs.existsSync(targetIModelFile)) {
-      IModelJsFs.removeSync(targetIModelFile);
-    }
     const sourceIModelDb: SnapshotDb = SnapshotDb.createEmpty(
       sourceIModelFile,
       {
@@ -1202,30 +1198,18 @@ describe("IModelTransformer", () => {
   });
 
   it("remap non-root subject to non-root subject", async () => {
-    const sourceIModelName: string = "source";
-    const targetIModelName: string = "target";
-    const sourceIModelFile: string = path.join(
-      outputDir,
-      `${sourceIModelName}.bim`
-    );
-    const targetIModelFile: string = path.join(
-      outputDir,
-      `${targetIModelName}.bim`
-    );
-    // if (IModelJsFs.existsSync(sourceIModelFile)) {
-    //   IModelJsFs.removeSync(sourceIModelFile);
-    // }
+    const sourceIModelName: string = "source.bim";
+    const targetIModelName: string = "target.bim";
+    const sourceIModelFile: string = path.join(outputDir, sourceIModelName);
+    const targetIModelFile: string = path.join(outputDir, targetIModelName);
     IModelTransformerTestUtils.prepareOutputFile(
       "IModelTransformer",
-      sourceIModelFile
+      sourceIModelName
     );
     IModelTransformerTestUtils.prepareOutputFile(
       "IModelTransformer",
-      targetIModelFile
+      targetIModelName
     );
-    // if (IModelJsFs.existsSync(targetIModelFile)) {
-    //   IModelJsFs.removeSync(targetIModelFile);
-    // }
     const sourceIModelDb: SnapshotDb = SnapshotDb.createEmpty(
       sourceIModelFile,
       {
@@ -1275,22 +1259,18 @@ describe("IModelTransformer", () => {
   });
 
   it("remap root subject to non-root subject", async () => {
-    const sourceIModelName: string = "source";
-    const targetIModelName: string = "target";
-    const sourceIModelFile: string = path.join(
-      outputDir,
-      `${sourceIModelName}.bim`
+    const sourceIModelName: string = "source.bim";
+    const targetIModelName: string = "target.bim";
+    const sourceIModelFile: string = path.join(outputDir, sourceIModelName);
+    const targetIModelFile: string = path.join(outputDir, targetIModelName);
+    IModelTransformerTestUtils.prepareOutputFile(
+      "IModelTransformer",
+      sourceIModelName
     );
-    const targetIModelFile: string = path.join(
-      outputDir,
-      `${targetIModelName}.bim`
+    IModelTransformerTestUtils.prepareOutputFile(
+      "IModelTransformer",
+      targetIModelName
     );
-    if (IModelJsFs.existsSync(sourceIModelFile)) {
-      IModelJsFs.removeSync(sourceIModelFile);
-    }
-    if (IModelJsFs.existsSync(targetIModelFile)) {
-      IModelJsFs.removeSync(targetIModelFile);
-    }
     const sourceIModelDb: SnapshotDb = SnapshotDb.createEmpty(
       sourceIModelFile,
       {
@@ -1327,22 +1307,18 @@ describe("IModelTransformer", () => {
   });
 
   it("remap root subject to non-root subject with non-root parent", async () => {
-    const sourceIModelName: string = "source";
-    const targetIModelName: string = "target";
-    const sourceIModelFile: string = path.join(
-      outputDir,
-      `${sourceIModelName}.bim`
+    const sourceIModelName: string = "source.bim";
+    const targetIModelName: string = "target.bim";
+    const sourceIModelFile: string = path.join(outputDir, sourceIModelName);
+    const targetIModelFile: string = path.join(outputDir, targetIModelName);
+    IModelTransformerTestUtils.prepareOutputFile(
+      "IModelTransformer",
+      sourceIModelName
     );
-    const targetIModelFile: string = path.join(
-      outputDir,
-      `${targetIModelName}.bim`
+    IModelTransformerTestUtils.prepareOutputFile(
+      "IModelTransformer",
+      targetIModelName
     );
-    if (IModelJsFs.existsSync(sourceIModelFile)) {
-      IModelJsFs.removeSync(sourceIModelFile);
-    }
-    if (IModelJsFs.existsSync(targetIModelFile)) {
-      IModelJsFs.removeSync(targetIModelFile);
-    }
     const sourceIModelDb: SnapshotDb = SnapshotDb.createEmpty(
       sourceIModelFile,
       {

--- a/packages/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -1007,15 +1007,19 @@ describe("IModelTransformer", () => {
         }
       );
       transformerA2S.context.remapElement(IModel.rootSubjectId, subjectId);
-      transformerA2S.importer.doNotUpdateElementIds.add(subjectId);
       await transformerA2S.processAll();
       transformerA2S.dispose();
+      // Make sure some properties, for example, description, can persist
+      const teamIModelA: Subject = iModelA.elements.getElement<Subject>(IModel.rootSubjectId);
+      const sharedIModelA: Subject= iModelShared.elements.getElement<Subject>(subjectId);
+      assert.equal(teamIModelA.description, sharedIModelA.description);
       IModelTransformerTestUtils.dumpIModelInfo(iModelA);
       iModelA.close();
       iModelShared.saveChanges("Imported A");
       IModelTransformerTestUtils.assertSharedIModelContents(iModelShared, [
         "A",
       ]);
+
     }
 
     if (true) {
@@ -1045,7 +1049,6 @@ describe("IModelTransformer", () => {
         }
       );
       transformerB2S.context.remapElement(IModel.rootSubjectId, subjectId);
-      transformerB2S.importer.doNotUpdateElementIds.add(subjectId);
       await transformerB2S.processAll();
       transformerB2S.dispose();
       IModelTransformerTestUtils.dumpIModelInfo(iModelB);


### PR DESCRIPTION
As https://github.com/iTwin/imodel-transformer/issues/149
Make root subject special cased when remapping from source to target

Fixed the bug on transformer side instead of native side as transformer is the only consumer of the corresponding native code