### PR TITLE
Revert "save and push changes after transformer is complete (#153)"

### DIFF
--- a/change/@itwin-imodel-transformer-359b2d25-3f51-4eab-b5d4-a6602ba69819.json
+++ b/change/@itwin-imodel-transformer-359b2d25-3f51-4eab-b5d4-a6602ba69819.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Revert \"save and push changes after transformer is complete (#153)\"",
+  "packageName": "@itwin/imodel-transformer",
+  "email": "22119573+nick4598@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -2302,7 +2302,6 @@ export class IModelTransformer extends IModelExportHandler {
       // transformation finalization, the work will be saved immediately, otherwise we've
       // just marked this changeset as a synchronization to ignore, and the user can add other
       // stuff to it which would break future synchronizations
-      // FIXME: force push for the user to prevent that
       for (
         let i = this._startingChangesetIndices.target + 1;
         i <= this.targetDb.changeset.index + 1;

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -374,37 +374,10 @@ export interface InitOptions {
 /**
  * Arguments for [[IModelTransformer.processChanges]]
  */
-export type ProcessChangesOptions = ExportChangesOptions &
-  FinalizeTransformationOptions;
-
-/**
- * Options which modify the behavior of [[IModelTransformer.finalizeTransformation]], called at the end of [[IModelTransformer.processAll]] and [[IModelTransformer.processChanges]].
- * @beta
- */
-export interface FinalizeTransformationOptions {
-  /**
-   * This description will be used when the transformer needs to push changes to the branch during a reverse sync.
-   * @default `Update provenance in response to a reverse sync to iModel: ${this.targetDb.iModelId}`
-   */
-  reverseSyncBranchChangesetDescription?: string;
-  /**
-   * This description will be used when the transformer needs to push changes to master during a reverse sync.
-   * @default `Reverse sync of iModel: ${this.sourceDb.iModelId}`
-   */
-  reverseSyncMasterChangesetDescription?: string;
-  /**
-   * This description will be used when the transformer needs to push changes to the branch during a forward sync.
-   * @default `Forward sync of iModel: ${this.sourceDb.iModelId}`
-   */
-  forwardSyncBranchChangesetDescription?: string;
-  /**
-   * This description will be used when the transformer needs to push changes to the branch during a provenance init transform.
-   * @default `initialized branch provenance with master iModel: ${this.sourceDb.iModelId}`
-   */
-  provenanceInitTransformChangesetDescription?: string;
+export type ProcessChangesOptions = ExportChangesOptions & {
   /** how to call saveChanges on the target. Must call targetDb.saveChanges, should not edit the iModel */
   saveTargetChanges?: (transformer: IModelTransformer) => Promise<void>;
-}
+};
 
 type ChangeDataState =
   | "uninited"
@@ -2325,6 +2298,11 @@ export class IModelTransformer extends IModelExportHandler {
             pendingReverseSyncChangesetIndicesKey,
           ];
 
+      // NOTE that as documented in [[processChanges]], this assumes that right after
+      // transformation finalization, the work will be saved immediately, otherwise we've
+      // just marked this changeset as a synchronization to ignore, and the user can add other
+      // stuff to it which would break future synchronizations
+      // FIXME: force push for the user to prevent that
       for (
         let i = this._startingChangesetIndices.target + 1;
         i <= this.targetDb.changeset.index + 1;
@@ -2371,9 +2349,7 @@ export class IModelTransformer extends IModelExportHandler {
   }
 
   // FIXME<MIKE>: is this necessary when manually using low level transform APIs? (document if so)
-  private async finalizeTransformation(
-    options?: FinalizeTransformationOptions
-  ) {
+  private finalizeTransformation() {
     this.importer.finalize();
     this.updateSynchronizationVersion();
 
@@ -2405,36 +2381,6 @@ export class IModelTransformer extends IModelExportHandler {
       (this.targetDb as any).codeValueBehavior = "trim-unicode-whitespace";
     }
     /* eslint-enable @itwin/no-internal */
-
-    const defaultSaveTargetChanges = () => this.targetDb.saveChanges();
-    await (options?.saveTargetChanges ?? defaultSaveTargetChanges)(this);
-    if (this.isReverseSynchronization) this.sourceDb.saveChanges();
-
-    const description = `${
-      this._isProvenanceInitTransform
-        ? options?.provenanceInitTransformChangesetDescription ??
-          `initialized branch provenance with master iModel: ${this.sourceDb.iModelId}`
-        : this.isForwardSynchronization
-          ? options?.forwardSyncBranchChangesetDescription ??
-            `Forward sync of iModel: ${this.sourceDb.iModelId}`
-          : options?.reverseSyncMasterChangesetDescription ??
-            `Reverse sync of iModel: ${this.sourceDb.iModelId}`
-    }`;
-
-    if (this.targetDb.isBriefcaseDb()) {
-      // This relies on authorizationClient on iModelHost being defined, otherwise this will fail
-      await this.targetDb.pushChanges({
-        description,
-      });
-    }
-    if (this.isReverseSynchronization && this.sourceDb.isBriefcaseDb()) {
-      // This relies on authorizationClient on iModelHost being defined, otherwise this will fail
-      await this.sourceDb.pushChanges({
-        description:
-          options?.reverseSyncBranchChangesetDescription ??
-          `Update provenance in response to a reverse sync to iModel: ${this.targetDb.iModelId}`,
-      });
-    }
   }
 
   /** Imports all relationships that subclass from the specified base class.
@@ -3257,9 +3203,7 @@ export class IModelTransformer extends IModelExportHandler {
   /** Export everything from the source iModel and import the transformed entities into the target iModel.
    * @note [[processSchemas]] is not called automatically since the target iModel may want a different collection of schemas.
    */
-  public async processAll(
-    options?: FinalizeTransformationOptions
-  ): Promise<void> {
+  public async processAll(): Promise<void> {
     this.logSettings();
     this.initScopeProvenance();
     await this.initialize();
@@ -3297,7 +3241,7 @@ export class IModelTransformer extends IModelExportHandler {
       this.importer.optimizeGeometry(this._options.optimizeGeometry);
 
     this.importer.computeProjectExtents();
-    await this.finalizeTransformation(options);
+    this.finalizeTransformation();
   }
 
   /** previous provenance, either a federation guid, a `${sourceFedGuid}/${targetFedGuid}` pair, or required aspect props */
@@ -3323,7 +3267,9 @@ export class IModelTransformer extends IModelExportHandler {
 
   /** Export changes from the source iModel and import the transformed entities into the target iModel.
    * Inserts, updates, and deletes are determined by inspecting the changeset(s).
-   * @note the transformer saves and pushes changes when its work is complete.
+   * @note the transformer assumes that you saveChanges after processing changes. You should not
+   * modify the iModel after processChanges until saveChanges, failure to do so may result in corrupted
+   * data loss in future branch operations
    * @note if no startChangesetId or startChangeset option is provided as part of the ProcessChangesOptions, the next unsynchronized changeset
    * will automatically be determined and used
    * @note To form a range of versions to process, set `startChangesetId` for the start (inclusive) of the desired range and open the source iModel as of the end (inclusive) of the desired range.
@@ -3343,8 +3289,13 @@ export class IModelTransformer extends IModelExportHandler {
       this.importer.optimizeGeometry(this._options.optimizeGeometry);
 
     this.importer.computeProjectExtents();
+    this.finalizeTransformation();
 
-    await this.finalizeTransformation(options);
+    const defaultSaveTargetChanges = () => {
+      this.targetDb.saveChanges();
+    };
+
+    await (options.saveTargetChanges ?? defaultSaveTargetChanges)(this);
   }
 
   /** Changeset data must be initialized in order to build correct changeOptions.

--- a/packages/transformer/src/test/TestUtils/TimelineTestUtil.ts
+++ b/packages/transformer/src/test/TestUtils/TimelineTestUtil.ts
@@ -25,7 +25,6 @@ import {
 } from "@itwin/core-common";
 import { Point3d, YawPitchRollAngles } from "@itwin/core-geometry";
 import {
-  FinalizeTransformationOptions,
   IModelTransformer,
   IModelTransformOptions,
 } from "../../IModelTransformer";
@@ -259,7 +258,6 @@ export type TimelineStateChange =
           assert?: {
             afterProcessChanges?: (transformer: IModelTransformer) => void;
           };
-          finalizeTransformationOptions?: FinalizeTransformationOptions;
         },
       ];
     }
@@ -364,7 +362,6 @@ export async function runTimeline(
             assert?: {
               afterProcessChanges?: (transformer: IModelTransformer) => void;
             };
-            finalizeTransformationOptions?: FinalizeTransformationOptions;
           },
         ]
       | undefined;
@@ -504,7 +501,6 @@ export async function runTimeline(
             initTransformer,
             expectThrow,
             assert: assertFxns,
-            finalizeTransformationOptions,
           },
         ] = getSync(event)!;
         // if the synchronization source is master, it's a normal sync
@@ -525,7 +521,6 @@ export async function runTimeline(
           await syncer.processChanges({
             accessToken,
             startChangeset: startIndex ? { index: startIndex } : undefined,
-            ...finalizeTransformationOptions,
           });
           expect(
             expectThrow === false || expectThrow === undefined,

--- a/packages/transformer/src/test/TestUtils/TimelineTestUtil.ts
+++ b/packages/transformer/src/test/TestUtils/TimelineTestUtil.ts
@@ -453,6 +453,11 @@ export async function runTimeline(
         });
         await provenanceInserter.processAll();
         provenanceInserter.dispose();
+        await saveAndPushChanges(
+          accessToken,
+          branchDb,
+          "initialized branch provenance"
+        );
       } else if ("seed" in newIModelEvent) {
         await saveAndPushChanges(
           accessToken,
@@ -558,6 +563,12 @@ export async function runTimeline(
         }
 
         target.state = getIModelState(target.db); // update the tracking state
+
+        if (!expectThrow) {
+          if (!isForwardSync)
+            await saveAndPushChanges(accessToken, source.db, stateMsg);
+          await saveAndPushChanges(accessToken, target.db, stateMsg);
+        }
       } else {
         const alreadySeenIModel = trackedIModels.get(iModelName)!;
         let stateMsg: string;

--- a/packages/transformer/src/test/standalone/IModelTransformerHub.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformerHub.test.ts
@@ -75,7 +75,6 @@ import {
 } from "@itwin/core-common";
 import { Point3d, YawPitchRollAngles } from "@itwin/core-geometry";
 import {
-  FinalizeTransformationOptions,
   IModelExporter,
   IModelImporter,
   IModelTransformer,
@@ -3242,89 +3241,6 @@ describe("IModelTransformerHub", () => {
 
     await tearDown();
     sinon.restore();
-  });
-
-  it("should allow custom changeset descriptions", async () => {
-    const pushChangeset = sinon.spy(HubMock, "pushChangeset");
-    const csDescriptions: FinalizeTransformationOptions = {
-      forwardSyncBranchChangesetDescription:
-        "this is a test forward sync on the branch",
-      reverseSyncBranchChangesetDescription:
-        "this is a test reverse sync on the branch",
-      reverseSyncMasterChangesetDescription:
-        "this is a test reverse sync on the master",
-    };
-    const makeCsPropsDescriptionMatcher = (description: string) => {
-      return sinon.match.has(
-        "changesetProps",
-        sinon.match.has("description", description)
-      );
-    };
-    const timeline: Timeline = [
-      { master: { 1: 1, 2: 2, 3: 1 } },
-      { branch: { branch: "master" } },
-      { branch: { 1: 2, 4: 1 } },
-      {
-        master: {
-          sync: ["branch", { finalizeTransformationOptions: csDescriptions }],
-        },
-      },
-      {
-        assert() {
-          expect(
-            pushChangeset.calledWith(
-              makeCsPropsDescriptionMatcher(
-                csDescriptions.reverseSyncBranchChangesetDescription!
-              )
-            )
-          ).to.be.true;
-          expect(
-            pushChangeset.calledWith(
-              makeCsPropsDescriptionMatcher(
-                csDescriptions.reverseSyncMasterChangesetDescription!
-              )
-            )
-          ).to.be.true;
-
-          // We haven't passed csDescriptions to a forward sync yet so expect false
-          expect(
-            pushChangeset.calledWith(
-              makeCsPropsDescriptionMatcher(
-                csDescriptions.forwardSyncBranchChangesetDescription!
-              )
-            )
-          ).to.be.false;
-        },
-      },
-      { master: { 5: 1 } },
-      {
-        branch: {
-          sync: ["master", { finalizeTransformationOptions: csDescriptions }],
-        },
-      },
-      {
-        assert() {
-          expect(
-            pushChangeset.calledWith(
-              makeCsPropsDescriptionMatcher(
-                csDescriptions.forwardSyncBranchChangesetDescription!
-              )
-            )
-          ).to.be.true;
-        },
-      },
-    ];
-
-    const { tearDown } = await runTimeline(timeline, {
-      iTwinId,
-      accessToken,
-      transformerOpts: {
-        // force aspects so that reverse sync has to edit the target
-        forceExternalSourceAspectProvenance: true,
-      },
-    });
-
-    await tearDown();
   });
 
   it("should be able to handle a transformation which deletes a relationship and then elements of that relationship", async () => {


### PR DESCRIPTION
Leaving the responsibility up to the consumer. We already require them to download the iModels and acquire locks themselves, so we should also let them push changes as pushing changes releases locks. 

There have also been mentions of some transforms intentionally inserting data that isn't meant to be transformed back over, which would not be possible if we pushed changes for consumers, because then they wouldn't be able to add that data as part of the pending changeset indices.