### PR TITLE
fix prepare-fork.ts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,6 +31,17 @@
         "skipFiles": [
           "<node_internals>/**"
         ]
+      },
+      {
+        "type": "node",
+        "request": "launch",
+        "name": "Performance tests",
+        "runtimeExecutable": "npm",
+        "cwd": "${workspaceFolder}/packages/performance-tests/test",
+        "runtimeArgs": [
+          "run",
+          "test"
+        ],
       }
     ]
 }

--- a/packages/performance-tests/test/cases/prepare-fork.ts
+++ b/packages/performance-tests/test/cases/prepare-fork.ts
@@ -41,9 +41,6 @@ export default async function prepareFork(context: TestCaseContext) {
     [timer] = await timed(async () => {
       await branchInitializer.run();
     });
-    // save+push our changes to whatever hub we're using
-    const description = "initialized branch iModel";
-    branchDb.saveChanges(description);
 
     Logger.logInfo(
       loggerCategory,


### PR DESCRIPTION
When fed guid opt branch was merged there was a change in initializeBranchProvenance() function which closed the master and branch imodel if createFedGuidsForMaster: true,. Because of this when the test tried to peform saveChanges() it would fail.
I decided to just remove save changes because performing .close() on the imodels should save changes before closing. This should be better for the context of a perf test so time isn't wasted reopening the imodel just to save changes and then close again.