### PR TITLE
Refactored `hasElementChanged()` in iModelTransformer not to store cache with changed elements

### DIFF
--- a/packages/transformer/src/IModelExporter.ts
+++ b/packages/transformer/src/IModelExporter.ts
@@ -168,10 +168,7 @@ export abstract class IModelExportHandler {
    * @param isUpdate If defined, then `true` indicates an UPDATE operation while `false` indicates an INSERT operation. If not defined, then INSERT vs. UPDATE is not known.
    * @note This should be overridden to actually do the export.
    */
-  public onExportElement(
-    _element: Element,
-    _isUpdate: boolean | undefined
-  ): void {}
+  public onExportElement(_element: Element): void {}
 
   /**
    * Do any asynchronous actions before exporting an element
@@ -842,13 +839,6 @@ export class IModelExporter {
       return;
     }
 
-    // are we processing changes?
-    const isUpdate = this._sourceDbChanges?.element.insertIds.has(elementId)
-      ? false
-      : this._sourceDbChanges?.element.updateIds.has(elementId)
-        ? true
-        : undefined;
-
     const element = this.sourceDb.elements.getElement({
       id: elementId,
       wantGeometry: this.wantGeometry,
@@ -856,14 +846,12 @@ export class IModelExporter {
     });
     Logger.logTrace(
       loggerCategory,
-      `exportElement(${
-        element.id
-      }, "${element.getDisplayLabel()}")${this.getChangeOpSuffix(isUpdate)}`
+      `exportElement(${element.id}, "${element.getDisplayLabel()}")`
     );
     // the order and `await`ing of calls beyond here is depended upon by the IModelTransformer for a current bug workaround
     if (this.shouldExportElement(element)) {
       await this.handler.preExportElement(element);
-      this.handler.onExportElement(element, isUpdate);
+      this.handler.onExportElement(element);
       await this.trackProgress();
       await this._exportElementAspectsStrategy.exportElementAspectsForElement(
         elementId

--- a/packages/transformer/src/test/IModelTransformerUtils.ts
+++ b/packages/transformer/src/test/IModelTransformerUtils.ts
@@ -1890,7 +1890,7 @@ export class AssertOrderTransformer extends IModelTransformer {
     return `The elements [${this._exportOrderQueue}] remain`;
   }
 
-  public override onExportElement(elem: Element) {
+  public override onExportElement(elem: Element): void {
     if (elem.id === this._exportOrderQueue[0]) this._exportOrderQueue.shift(); // pop the front
     // we just popped the queue if it was expected, so it shouldn't be there the order was correct (and there are no duplicates)
     const currentExportWasNotInExpectedOrder = this._exportOrderQueue.includes(
@@ -2203,18 +2203,15 @@ export class IModelToTextFileExporter extends IModelExportHandler {
     );
     super.onExportModel(model, isUpdate);
   }
-  public override onExportElement(
-    element: Element,
-    isUpdate: boolean | undefined
-  ): void {
+  public override onExportElement(element: Element): void {
     const indentLevel: number = this.getIndentLevelForElement(element);
     this.writeLine(
       `[Element] ${element.classFullName}, ${
         element.id
-      }, ${element.getDisplayLabel()}${this.formatOperationName(isUpdate)}`,
+      }, ${element.getDisplayLabel()}`,
       indentLevel
     );
-    super.onExportElement(element, isUpdate);
+    super.onExportElement(element);
   }
   public override onDeleteElement(elementId: Id64String): void {
     this.writeLine(`[Element] ${elementId}, DELETE`);
@@ -2351,12 +2348,9 @@ export class ClassCounter extends IModelExportHandler {
     this.incrementClassCount(this._modelClassCounts, model.classFullName);
     super.onExportModel(model, isUpdate);
   }
-  public override onExportElement(
-    element: Element,
-    isUpdate: boolean | undefined
-  ): void {
+  public override onExportElement(element: Element): void {
     this.incrementClassCount(this._elementClassCounts, element.classFullName);
-    super.onExportElement(element, isUpdate);
+    super.onExportElement(element);
   }
   public override onExportElementUniqueAspect(
     aspect: ElementUniqueAspect,

--- a/packages/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -1573,10 +1573,7 @@ describe("IModelTransformer", () => {
       ): void {
         ++this.modelCount;
       }
-      public override onExportElement(
-        _element: Element,
-        _isUpdate: boolean | undefined
-      ): void {
+      public override onExportElement(_element: Element): void {
         assert.fail("Should not visit element when visitElements=false");
       }
       public override onExportRelationship(


### PR DESCRIPTION
Changes for #229 

 - In previous implementation `_hasElementChangedCache` was populated from change sets. Removed `_hasElementChangedCache` from `iModelTransformer`.  Transformer will check `this.exporter.sourceDbChanges` instead. Due to this change there will be only one source of truth to check changed elements.
 - Changed elements are still skipped in iModelTransformer (not in exporter as it was suggested in #229) as some transformer implementations rely on this logic. Also transformer remaps element ids, before skipping it.
 - Added breaking change to remove `isUpdated` parameter from `onExportElement()` as this parameter was not used anyway. 
 - Added trace logging about skipped elements to `iModelTransformer`. It replaces logging where Exported was logging 'isUpdated' parameter value.