### PR TITLE
Ignore navigational properties that point to an ECView

### DIFF
--- a/change/@itwin-imodel-transformer-70f1f73f-ad6a-4ee1-adb2-41372b822905.json
+++ b/change/@itwin-imodel-transformer-70f1f73f-ad6a-4ee1-adb2-41372b822905.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ignore navigational properties that point to an ECView",
+  "packageName": "@itwin/imodel-transformer",
+  "email": "36619139+ViliusRuskys@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/transformer/src/ECReferenceTypesCache.ts
+++ b/packages/transformer/src/ECReferenceTypesCache.ts
@@ -221,6 +221,17 @@ export class ECReferenceTypesCache {
       ECReferenceTypesCache.bisRootClassToRefType[sourceRootBisClass.name];
     const targetType =
       ECReferenceTypesCache.bisRootClassToRefType[targetRootBisClass.name];
+    if (
+      (!sourceType &&
+        sourceRootBisClass.customAttributes?.has("ECDbMap.QueryView")) ||
+      (!targetType &&
+        targetRootBisClass.customAttributes?.has("ECDbMap.QueryView"))
+    ) {
+      // ECView elements are not "real" data and transformer does not need to process them.
+      // Relationships that point to ECView elements can only be used in ECViews so the mapping is not needed.
+      return undefined;
+    }
+
     const makeAssertMsg = (root: ECClass, cls: ECClass) =>
       [
         `An unknown root class '${root.fullName}' was encountered while populating`,

--- a/packages/transformer/src/test/assets/TestQueryView.ecschema.xml
+++ b/packages/transformer/src/test/assets/TestQueryView.ecschema.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ECSchema schemaName="TestGeneratedClassesNew" alias="tgcn" version="1.0.0"
+    xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+    <ECSchemaReference name="CoreCustomAttributes" version="01.00.03" alias="CoreCA"/>
+    <ECSchemaReference name="BisCustomAttributes" version="01.00.00" alias="bisCA"/>
+    <ECSchemaReference name="ECdbMap" version="02.00.04" alias="ecdbmap"/>
+    <ECSchemaReference name="BisCore" version="01.00.16" alias="bis"/>
+
+    <ECEntityClass typeName="TestView" modifier="Abstract" displayLabel="Test View" description="a sample view">
+        <ECCustomAttributes>
+            <QueryView xmlns="ECDbMap.02.00.04">
+                <Query>
+                    SELECT
+                        pe.ECInstanceId,
+                        ec_classid('TestGeneratedClassesNew', 'TestView') [ECClassId],
+                        pe.Yaw as Yaw,
+                        NAVIGATION_VALUE(bis.PhysicalElement.Parent, pe.Parent.Id) as Parent
+                    FROM bis.PhysicalElement pe
+                </Query>
+            </QueryView>
+        </ECCustomAttributes>
+        <ECProperty propertyName="Yaw" typeName="double" description="Yaw of the PhysicalElement"/>
+        <ECNavigationProperty propertyName="Parent" relationshipName="PhysicalElementOwnsTestView" direction="backward" description="The parent Element that owns this element"/>
+    </ECEntityClass>
+
+    <ECRelationshipClass typeName="PhysicalElementOwnsTestView" strength="embedding" modifier="None" description="Relationship between an PhysicalElement and a TestView.">
+        <Source multiplicity="(1..1)" roleLabel="owns" polymorphic="true">
+            <Class class="bis:PhysicalElement"/>
+        </Source>
+        <Target multiplicity="(1..*)" roleLabel="is owned by" polymorphic="true">
+            <Class class="TestView"/>
+        </Target>
+    </ECRelationshipClass>
+
+</ECSchema>

--- a/packages/transformer/src/test/standalone/ECReferenceTypesCache.test.ts
+++ b/packages/transformer/src/test/standalone/ECReferenceTypesCache.test.ts
@@ -13,12 +13,17 @@ import { KnownTestLocations as BackendTestsKnownLocations } from "../TestUtils/K
 import * as Semver from "semver";
 import { Schema, SchemaItemType, SchemaLoader } from "@itwin/ecschema-metadata";
 import * as sinon from "sinon";
+import { version as iTwinCoreBackendVersion } from "@itwin/core-backend/package.json";
 
 describe("ECReferenceTypesCache", () => {
   let testIModel: SnapshotDb;
   const testSchemaPath = path.join(
     BackendTestsKnownLocations.assetsDir,
     "TestGeneratedClasses.ecschema.xml"
+  );
+  const testSchemaPathWithQueryView = path.join(
+    BackendTestsKnownLocations.assetsDir,
+    "TestQueryView.ecschema.xml"
   );
   const testFixtureRefCache = new ECReferenceTypesCache();
   let pathForEmpty: string;
@@ -183,6 +188,20 @@ describe("ECReferenceTypesCache", () => {
         "PhysicalMaterial"
       )
     ).to.equal(ConcreteEntityTypes.Element);
+  });
+
+  it("should handle QueryView", async () => {
+    if (!Semver.gte(iTwinCoreBackendVersion, "4.6.0")) {
+      return; // Pre 4.6.0 does not have QueryView support. https://www.itwinjs.org/bis/domains/ecdbmap.ecschema/#queryview
+    }
+    const thisTestRefCache = new ECReferenceTypesCache();
+    const ecdbMapVersion =
+      emptyWithBrandNewBiscore.querySchemaVersion("ECdbMap");
+    assert(ecdbMapVersion !== undefined);
+    assert(Semver.gte(ecdbMapVersion, "2.0.4"));
+    await emptyWithBrandNewBiscore.importSchemas([testSchemaPathWithQueryView]);
+    emptyWithBrandNewBiscore.saveChanges();
+    await thisTestRefCache.initAllSchemasInIModel(emptyWithBrandNewBiscore);
   });
 
   it("should not init schemas of a lower or equal version", async () => {

--- a/packages/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -132,7 +132,6 @@ import "./TransformerTestStartup"; // calls startup/shutdown IModelHost before/a
 import { SchemaLoader } from "@itwin/ecschema-metadata";
 import { DetachedExportElementAspectsStrategy } from "../../DetachedExportElementAspectsStrategy";
 import { SchemaTestUtils } from "../TestUtils";
-import { version as iTwinCoreBackendVersion } from "@itwin/core-backend/package.json";
 
 describe("IModelTransformer", () => {
   const outputDir = path.join(
@@ -5190,7 +5189,7 @@ describe("IModelTransformer", () => {
   });
 
   it("should transform iModel with ECView successfully", async function () {
-    if (!Semver.gte(iTwinCoreBackendVersion, "4.6.0")) {
+    if (!Semver.gte(coreBackendPkgJson.version, "4.6.0")) {
       return; // Pre 4.6.0 does not have QueryView support. https://www.itwinjs.org/bis/domains/ecdbmap.ecschema/#queryview
     }
     const createSnapshot = (name: string): SnapshotDb => {

--- a/packages/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -81,6 +81,7 @@ import {
   ElementProps,
   ExternalSourceAspectProps,
   GeometricElement2dProps,
+  GeometricElement3dProps,
   ImageSourceFormat,
   IModel,
   IModelError,
@@ -131,6 +132,7 @@ import "./TransformerTestStartup"; // calls startup/shutdown IModelHost before/a
 import { SchemaLoader } from "@itwin/ecschema-metadata";
 import { DetachedExportElementAspectsStrategy } from "../../DetachedExportElementAspectsStrategy";
 import { SchemaTestUtils } from "../TestUtils";
+import { version as iTwinCoreBackendVersion } from "@itwin/core-backend/package.json";
 
 describe("IModelTransformer", () => {
   const outputDir = path.join(
@@ -5182,6 +5184,94 @@ describe("IModelTransformer", () => {
         sampleIntervalMicroSec: 30, // this is a quick transformation, let's get more resolution
       }
     );
+    transformer.dispose();
+    sourceDb.close();
+    targetDb.close();
+  });
+
+  it("should transform iModel with ECView successfully", async function () {
+    if (!Semver.gte(iTwinCoreBackendVersion, "4.6.0")) {
+      return; // Pre 4.6.0 does not have QueryView support. https://www.itwinjs.org/bis/domains/ecdbmap.ecschema/#queryview
+    }
+    const createSnapshot = (name: string): SnapshotDb => {
+      return SnapshotDb.createEmpty(
+        IModelTransformerTestUtils.prepareOutputFile(
+          "IModelTransformer",
+          `${name}.bim`
+        ),
+        { rootSubject: { name } }
+      );
+    };
+    const sourceDb = createSnapshot("ECView-Source");
+    const targetDb = createSnapshot("ECView-Target");
+    await sourceDb.importSchemas([
+      path.join(KnownTestLocations.assetsDir, "TestQueryView.ecschema.xml"),
+    ]);
+
+    const modelId = PhysicalModel.insert(
+      sourceDb,
+      IModel.rootSubjectId,
+      "PhysicalModel"
+    );
+    const categoryId = SpatialCategory.insert(
+      sourceDb,
+      IModel.dictionaryId,
+      "SpatialCategory",
+      {}
+    );
+    const elementProps1: GeometricElement3dProps = {
+      category: categoryId,
+      model: modelId,
+      code: PhysicalType.createCode(sourceDb, modelId, "PhysicalObject1"),
+      classFullName: PhysicalObject.classFullName,
+      placement: {
+        origin: { x: 0, y: 0, z: 0 },
+        angles: { yaw: { degrees: 45 } },
+      },
+    };
+    const sourceElement1Id = sourceDb.elements.insertElement(elementProps1);
+    const elementProps2: GeometricElement3dProps = {
+      category: categoryId,
+      model: modelId,
+      code: PhysicalType.createCode(sourceDb, modelId, "PhysicalObject2"),
+      classFullName: PhysicalObject.classFullName,
+      parent: {
+        id: sourceElement1Id,
+        relClassName: ElementOwnsChildElements.classFullName,
+      },
+      placement: {
+        origin: { x: 0, y: 0, z: 0 },
+        angles: { yaw: { degrees: 90 } },
+      },
+    };
+    sourceDb.elements.insertElement(elementProps2);
+    sourceDb.saveChanges();
+
+    const transformer = new IModelTransformer(sourceDb, targetDb);
+    await transformer.processSchemas();
+    await transformer.process();
+    targetDb.saveChanges();
+
+    const getTestViewElements = (imodelDb: IModelDb) => {
+      return imodelDb.withPreparedStatement(
+        "SELECT * FROM TestGeneratedClassesNew.TestView",
+        (statement) => {
+          const viewElements = [];
+          while (DbResult.BE_SQLITE_ROW === statement.step()) {
+            viewElements.push(statement.getRow());
+          }
+          return viewElements;
+        }
+      );
+    };
+    const sourceViews = getTestViewElements(sourceDb);
+    const targetViews = getTestViewElements(targetDb);
+
+    expect(sourceViews.length).to.equal(targetViews.length).and.to.equal(2);
+    expect(sourceViews[0]).to.deep.equal(targetViews[0]);
+    expect(sourceViews[1]).to.deep.equal(targetViews[1]);
+
+    // clean up
     transformer.dispose();
     sourceDb.close();
     targetDb.close();


### PR DESCRIPTION
ECView elements are not "real" data and transformer does not need to process them. Relationships that point to an ECView instance are only allowed on ECView elements themselves, hence we don't need to track these relationships.
