### PR TITLE
Tests for Importing Lines Styles

### DIFF
--- a/packages/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -5264,11 +5264,9 @@ describe("IModelTransformer", () => {
     const transformer = new IModelTransformer(iModelDb, targetDb);
     await transformer.process();
 
-    const copiedElement = targetDb.elements.getElementProps(code1);
-    console.log(
-      iModelDb.elements.getElement(graphicElement1Props.id!).toJSON()
-    );
-    console.log(copiedElement.model);
+    const copiedElement = targetDb.elements.getElement("0x17");
+    console.log(iModelDb.elements.getElement("0x14").toJSON());
+    console.log(copiedElement.toJSON());
 
     transformer.dispose();
     iModelDb.close();

--- a/packages/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -5147,7 +5147,7 @@ describe("IModelTransformer", () => {
     targetDb.close();
   });
 
-  it("should import line style from geometry stream", async function () {
+  it.only("should import line style from geometry stream", async function () {
     const sourceDbFile: string = IModelTransformerTestUtils.prepareOutputFile(
       "IModelTransformer",
       "LineStyle.bim"
@@ -5277,7 +5277,7 @@ describe("IModelTransformer", () => {
     targetDb.close();
   });
 
-  it.only("should import compound line style from geometry stream", async function () {
+  it("should import compound line style from geometry stream", async function () {
     const sourceDbFile: string = IModelTransformerTestUtils.prepareOutputFile(
       "IModelTransformer",
       "CompoundLineStyle.bim"


### PR DESCRIPTION
Test for importing regular and compound line styles when preforming process all on imodels with line style elements. Tested on changes from:
https://github.com/iTwin/imodel-native/pull/1024

Original issue:
https://github.com/iTwin/imodel-transformer/issues/231

This pr is targeted for itwinjs-v5 as when I was working on the changes in imodel-native it was easier to work on imodel-native main vs release branches. Should these changes be needed in 4.x we can back port the native changes and these tests