### PR TITLE
Fix for custom changes API to create a deep copy of `set` before modifying it.

### DIFF
--- a/change/@itwin-imodel-transformer-d641f741-5460-4382-91ac-8e82a71922c1.json
+++ b/change/@itwin-imodel-transformer-d641f741-5460-4382-91ac-8e82a71922c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix for custom changes API to create a deep copy of set before modifying it.",
+  "packageName": "@itwin/imodel-transformer",
+  "email": "28706674+JulijaRamoskiene@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/transformer/src/IModelExporter.ts
+++ b/packages/transformer/src/IModelExporter.ts
@@ -1212,7 +1212,7 @@ export class ChangedInstanceIds {
       return;
     }
 
-    const idsSet = Id64.toIdSet(ids);
+    const idsSet = Id64.toIdSet(ids, true);
     // Parent models have to be marked as 'Updated' to make sure that added change is not skipped by transformer. Transformer starts processing elements from RepositoryModel and then visits all child models.
     // Transformer handles update as insert if element is not found in target, for this reason modeled elements will be also marked as updated to trigger their inserts in case a new model (or its parent) needs to be inserted. Otherwise error would be thrown about missing modeled element while inserting new model.
     const parentModelIds = await this.markParentModelsAsUpdated(idsSet);

--- a/packages/transformer/src/test/standalone/ChangedInstanceIds.test.ts
+++ b/packages/transformer/src/test/standalone/ChangedInstanceIds.test.ts
@@ -380,6 +380,45 @@ describe("ChangedInstanceIds", () => {
       );
     });
 
+    it("should add custom changes when set with multiple models is passed to insert", async function () {
+      // Arrange
+      const sourceDbChanges = new ChangedInstanceIds(sourceDb);
+      await sourceDbChanges.addCustomModelChange(
+        "Inserted",
+        new Set([childDrawing1.id!, childDrawing2.id!])
+      );
+
+      // Act
+      assertHasValues(
+        sourceDbChanges.element,
+        "element",
+        [childDrawing1.id!, childDrawing2.id!],
+        ["0x1", documentListModel, parentDrawing.id!],
+        []
+      );
+      assertHasValues(
+        sourceDbChanges.model,
+        "model",
+        [childDrawing1.id!, childDrawing2.id!],
+        ["0x1", documentListModel, parentDrawing.id!],
+        []
+      );
+      assertHasValues(
+        sourceDbChanges.aspect,
+        "aspect",
+        [aspect1Id, aspect2Id, parentAspect1Id],
+        [],
+        []
+      );
+      assertHasValues(
+        sourceDbChanges.relationship,
+        "relationship",
+        [relationshipId, parentRelationshipId],
+        [],
+        []
+      );
+    });
+
     it("should add custom changes when model is Updated", async function () {
       const sourceDbChanges = new ChangedInstanceIds(sourceDb);
       await sourceDbChanges.addCustomModelChange("Updated", parentDrawing.id!);


### PR DESCRIPTION
Custom changes API was unintentionally modifying a set passed by user, added a fix to create deep copy before doing modifications.
 
Fixes #251