### PR TITLE
Transform Linearly Located Imodels

### DIFF
--- a/change/@itwin-imodel-transformer-02446d05-5e05-4b3b-a64c-26b127724749.json
+++ b/change/@itwin-imodel-transformer-02446d05-5e05-4b3b-a64c-26b127724749.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "allow option to transform spatial elements of linearly located imodels",
+  "packageName": "@itwin/imodel-transformer",
+  "email": "'DanRod1999@users.noreply.github.com'",
+  "dependentChangeType": "patch"
+}

--- a/common/api/imodel-transformer.api.md
+++ b/common/api/imodel-transformer.api.md
@@ -244,6 +244,7 @@ export interface IModelImportOptions {
 export class IModelTransformer extends IModelExportHandler {
     constructor(source: IModelDb | IModelExporter, target: IModelDb | IModelImporter, options?: IModelTransformOptions);
     protected addCustomChanges(_sourceDbChanges: ChangedInstanceIds): Promise<void>;
+    calculateEcefTransform(srcDb: IModelDb, targetDb: IModelDb): Transform;
     combineElements(sourceElementIds: Id64Array, targetElementId: Id64String): void;
     // (undocumented)
     protected completePartiallyCommittedAspects(): void;
@@ -268,7 +269,6 @@ export class IModelTransformer extends IModelExportHandler {
         fn: (sourceElementId: Id64String, targetElementId: Id64String) => void;
         skipPropagateChangesToRootElements: boolean;
     }): void;
-    getEcefTransform(srcDb: IModelDb, targetDb: IModelDb): Transform;
     protected get hasDefinitionContainerDeletionFeature(): boolean;
     protected hasElementChanged(sourceElement: Element_2): boolean;
     readonly importer: IModelImporter;

--- a/common/api/imodel-transformer.api.md
+++ b/common/api/imodel-transformer.api.md
@@ -38,6 +38,7 @@ import { RelationshipProps } from '@itwin/core-backend';
 import { Schema } from '@itwin/ecschema-metadata';
 import { SchemaKey } from '@itwin/ecschema-metadata';
 import { SqliteChangeOp } from '@itwin/core-backend';
+import { Transform } from '@itwin/core-geometry';
 
 // @public
 export class ChangedInstanceIds {
@@ -158,6 +159,7 @@ export class IModelExporter {
     exportSubModels(parentModelId: Id64String): Promise<void>;
     protected get handler(): IModelExportHandler;
     initialize(options: ExporterInitOptions): Promise<void>;
+    linearlyTransformSpatialElements: boolean;
     progressInterval: number;
     registerHandler(handler: IModelExportHandler): void;
     shouldExportElement(element: Element_2): boolean;
@@ -266,6 +268,8 @@ export class IModelTransformer extends IModelExportHandler {
         fn: (sourceElementId: Id64String, targetElementId: Id64String) => void;
         skipPropagateChangesToRootElements: boolean;
     }): void;
+    // (undocumented)
+    getEcefTransform(srcDb: IModelDb, targetDb: IModelDb): Transform;
     protected get hasDefinitionContainerDeletionFeature(): boolean;
     protected hasElementChanged(sourceElement: Element_2): boolean;
     readonly importer: IModelImporter;

--- a/common/api/imodel-transformer.api.md
+++ b/common/api/imodel-transformer.api.md
@@ -159,7 +159,6 @@ export class IModelExporter {
     exportSubModels(parentModelId: Id64String): Promise<void>;
     protected get handler(): IModelExportHandler;
     initialize(options: ExporterInitOptions): Promise<void>;
-    linearlyTransformSpatialElements: boolean;
     progressInterval: number;
     registerHandler(handler: IModelExportHandler): void;
     shouldExportElement(element: Element_2): boolean;
@@ -258,6 +257,7 @@ export class IModelTransformer extends IModelExportHandler {
     static determineSyncType(sourceDb: IModelDb, targetDb: IModelDb,
     targetScopeElementId: Id64String): "forward" | "reverse";
     dispose(): void;
+    ecefTransform?: Transform;
     protected _elementsWithExplicitlyTrackedProvenance: Set<string>;
     readonly exporter: IModelExporter;
     static forEachTrackedElement(args: {
@@ -268,7 +268,6 @@ export class IModelTransformer extends IModelExportHandler {
         fn: (sourceElementId: Id64String, targetElementId: Id64String) => void;
         skipPropagateChangesToRootElements: boolean;
     }): void;
-    // (undocumented)
     getEcefTransform(srcDb: IModelDb, targetDb: IModelDb): Transform;
     protected get hasDefinitionContainerDeletionFeature(): boolean;
     protected hasElementChanged(sourceElement: Element_2): boolean;
@@ -358,6 +357,7 @@ export class IModelTransformer extends IModelExportHandler {
 
 // @beta
 export interface IModelTransformOptions {
+    alignECEFLocations?: boolean;
     argsForProcessChanges?: ProcessChangesOptions;
     branchRelationshipDataBehavior?: "unsafe-migrate" | "reject";
     cloneUsingBinaryGeometry?: boolean;

--- a/packages/transformer/src/IModelExporter.ts
+++ b/packages/transformer/src/IModelExporter.ts
@@ -293,6 +293,8 @@ export class IModelExporter {
   private _progressCounter: number = 0;
   /** Optionally cached entity change information */
   private _sourceDbChanges?: ChangedInstanceIds;
+  /** A flag that determines if spatial elements should be transformed if the src and target ECEF's of the imodels differ */
+  public linearlyTransformSpatialElements: boolean = false;
 
   /**
    * Retrieve the cached entity change information.

--- a/packages/transformer/src/IModelExporter.ts
+++ b/packages/transformer/src/IModelExporter.ts
@@ -293,10 +293,6 @@ export class IModelExporter {
   private _progressCounter: number = 0;
   /** Optionally cached entity change information */
   private _sourceDbChanges?: ChangedInstanceIds;
-  /** A flag that determines if spatial elements in the source db should be transformed if source and target ECEF's of the imodels differ
-   * @note This flag should only be used if imodels are linearly located
-   */
-  public alignECEFLocations: boolean = false;
 
   /**
    * Retrieve the cached entity change information.

--- a/packages/transformer/src/IModelExporter.ts
+++ b/packages/transformer/src/IModelExporter.ts
@@ -293,8 +293,10 @@ export class IModelExporter {
   private _progressCounter: number = 0;
   /** Optionally cached entity change information */
   private _sourceDbChanges?: ChangedInstanceIds;
-  /** A flag that determines if spatial elements should be transformed if the src and target ECEF's of the imodels differ */
-  public linearlyTransformSpatialElements: boolean = false;
+  /** A flag that determines if spatial elements in the source db should be transformed if source and target ECEF's of the imodels differ
+   * @note This flag should only be used if imodels are linearly located
+   */
+  public alignECEFLocations: boolean = false;
 
   /**
    * Retrieve the cached entity change information.

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -240,7 +240,7 @@ export interface IModelTransformOptions {
    * @default undefined
    */
   argsForProcessChanges?: ProcessChangesOptions;
-  /** A flag that determines if spatial elements in the source db should be transformed if source and target ECEF's of the imodels differ
+  /** A flag that determines if spatial elements from the source db should be transformed if source and target iModel ECEF locations differ.
    * @note This flag should only be used if imodels are linearly located
    * @default false
    */

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -1618,7 +1618,7 @@ export class IModelTransformer extends IModelExportHandler {
     const targetEcefLoc = targetDb.ecefLocation;
 
     if (
-      srcDb.geographicCoordinateSystem !== undefined &&
+      srcDb.geographicCoordinateSystem !== undefined ||
       targetDb.geographicCoordinateSystem !== undefined
     ) {
       throw new IModelError(

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -668,7 +668,7 @@ export class IModelTransformer extends IModelExportHandler {
     }
     /* eslint-enable @itwin/no-internal */
     this.ecefTransform = this._options.alignECEFLocations
-      ? this.getEcefTransform(this.sourceDb, this.targetDb)
+      ? this.calculateEcefTransform(this.sourceDb, this.targetDb)
       : undefined;
   }
 
@@ -1610,7 +1610,10 @@ export class IModelTransformer extends IModelExportHandler {
    * @returns Transform that converts relative coordinates in the source iModel to relative coordinates in the target iModel.
    * @note This can only be used if both source and target iModels are linearly located
    */
-  public getEcefTransform(srcDb: IModelDb, targetDb: IModelDb): Transform {
+  public calculateEcefTransform(
+    srcDb: IModelDb,
+    targetDb: IModelDb
+  ): Transform {
     const srcEcefLoc = srcDb.ecefLocation;
     const targetEcefLoc = targetDb.ecefLocation;
 

--- a/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
+++ b/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
@@ -1,0 +1,248 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import * as fs from "fs";
+import * as path from "path";
+import {
+  DefinitionModel,
+  GenericPhysicalType,
+  GeometricElement3d,
+  IModelDb,
+  IModelJsFs,
+  PhysicalModel,
+  PhysicalObject,
+  SnapshotDb,
+  SpatialCategory,
+  Subject,
+} from "@itwin/core-backend";
+import {
+  Cartographic,
+  Code,
+  ColorDef,
+  EcefLocation,
+  GeometryStreamBuilder,
+  PhysicalElementProps,
+} from "@itwin/core-common";
+import {
+  Geometry,
+  Point3d,
+  Sphere,
+  Transform,
+  YawPitchRollAngles,
+} from "@itwin/core-geometry";
+import { IModelTransformer3d } from "../IModelTransformerUtils";
+import { get } from "http";
+import { assert } from "console";
+
+describe("Linear Geolocation Transformations", () => {
+  function initOutputFile(fileBaseName: string) {
+    const outputDirName = path.join(__dirname, "output");
+    if (!IModelJsFs.existsSync(outputDirName)) {
+      IModelJsFs.mkdirSync(outputDirName);
+    }
+    const outputFileName = path.join(outputDirName, fileBaseName);
+    if (IModelJsFs.existsSync(outputFileName)) {
+      IModelJsFs.removeSync(outputFileName);
+    }
+    return outputFileName;
+  }
+
+  function convertLatLongToEcef(
+    longitude: number,
+    latitude: number
+  ): EcefLocation {
+    const cartographic = Cartographic.fromDegrees({
+      longitude,
+      latitude,
+      height: 0,
+    });
+    const ecef = EcefLocation.createFromCartographicOrigin(cartographic);
+
+    return ecef;
+  }
+
+  function createTestSnapshotDb(
+    ecef: EcefLocation,
+    dbName: string,
+    numElements: number = 1,
+    color: string = "red"
+  ): SnapshotDb {
+    const dbFileName = initOutputFile(`${dbName}.bim`);
+    const imodelDb = SnapshotDb.createEmpty(dbFileName, {
+      rootSubject: { name: dbName },
+      ecefLocation: ecef,
+    });
+    imodelDb.setEcefLocation(ecef);
+
+    const subjectId = Subject.insert(
+      imodelDb,
+      IModelDb.rootSubjectId,
+      "Test Subject"
+    );
+    const defintionModelId = DefinitionModel.insert(
+      imodelDb,
+      subjectId,
+      "DefinitionModel"
+    );
+
+    const categoryId = SpatialCategory.insert(
+      imodelDb,
+      defintionModelId,
+      `${color} Category`,
+      { color: ColorDef.fromString(color).toJSON() }
+    );
+
+    const modelId = PhysicalModel.insert(imodelDb, subjectId, "Test Model");
+
+    let x = 0,
+      y = 0,
+      z = 0;
+    const builder = new GeometryStreamBuilder();
+    builder.appendGeometry(Sphere.createCenterRadius(Point3d.createZero(), 1));
+    for (let i = 0; i < numElements; i++) {
+      if (i % 4 === 0 && i !== 0) {
+        x = 0;
+        y = 0;
+        z += 5;
+      } else if (i % 4 === 1) {
+        x += 5;
+      } else if (i % 4 === 2) {
+        y += 5;
+      } else {
+        x -= 5;
+      }
+
+      const elementProps: PhysicalElementProps = {
+        classFullName: PhysicalObject.classFullName,
+        model: modelId,
+        category: categoryId,
+        code: Code.createEmpty(),
+        geom: builder.geometryStream,
+        placement: {
+          origin: Point3d.create(x, y, z),
+          angles: YawPitchRollAngles.createDegrees(0, 0, 0),
+        },
+      };
+      imodelDb.elements.insertElement(elementProps);
+    }
+    imodelDb.saveChanges("Created test elements");
+
+    return imodelDb;
+  }
+
+  function getEcefFromExistingDb(filePath: string): EcefLocation {
+    const imodelDb = SnapshotDb.openFile(filePath);
+    const ecefLocation = imodelDb.ecefLocation;
+    if (ecefLocation === undefined) {
+      throw new Error("No ECEF location found in the iModel");
+    }
+    imodelDb.close();
+    return ecefLocation;
+  }
+
+  function getEcefTransform(
+    srcEcefLoc: EcefLocation,
+    targetEcefLoc: EcefLocation
+  ): Transform {
+    if (srcEcefLoc.getTransform().isAlmostEqual(targetEcefLoc.getTransform()))
+      return Transform.createIdentity();
+
+    const srcSpatialToECEF = srcEcefLoc.getTransform(); // converts relative to ECEF in relation to source
+    const targetECEFToSpatial = targetEcefLoc.getTransform().inverse()!; // converts ECEF to relative in relation to target
+    const ecefTransform =
+      srcSpatialToECEF.multiplyTransformTransform(targetECEFToSpatial); // chain both transforms
+
+    return ecefTransform;
+  }
+
+  async function getGeometric3dElements(
+    iModelDb: IModelDb
+  ): Promise<GeometricElement3d[]> {
+    const elements: GeometricElement3d[] = [];
+    const query = "SELECT ECInstanceId FROM bis.GeometricElement3d";
+    for await (const row of iModelDb.createQueryReader(query)) {
+      const element = iModelDb.elements.getElement<GeometricElement3d>(row.id);
+      elements.push(element);
+    }
+    return elements;
+  }
+
+  function getPositionDifference(
+    point1: Point3d,
+    point2: Point3d
+  ): { x: number; y: number; z: number } {
+    return {
+      x: point1.x - point2.x,
+      y: point1.y - point2.y,
+      z: point1.z - point2.z,
+    };
+  }
+
+  it.only("should create imodel", async function () {
+    // const srcEcef =   convertLatLongToEcef(39.95512097639021, -75.16578267595735) // 1515 Arch
+    // const targetEcef = convertLatLongToEcef(39.95595450339434, -75.16697176954752) // Bentley Cherry Street
+
+    // grab ecefs from existing iModels currently using ben's linearly located discs
+    const srcEcef = getEcefFromExistingDb(
+      "D:/GCS-transformer-poc/lib/output/source-iModel.bim"
+    );
+    const targetEcef = getEcefFromExistingDb(
+      "D:/GCS-transformer-poc/lib/output/target-iModel.bim"
+    );
+
+    // generate imodels with ecef locations specified above, and number of spherical elements inserted
+    const sourceDb = createTestSnapshotDb(
+      srcEcef,
+      "Source-ECEF-Transform",
+      12,
+      "red"
+    );
+    const targetDb = createTestSnapshotDb(
+      targetEcef,
+      "Target-ECEF-Transform",
+      12,
+      "blue"
+    );
+    assert(sourceDb.geographicCoordinateSystem === undefined);
+    assert(targetDb.geographicCoordinateSystem === undefined);
+    assert(sourceDb.ecefLocation !== undefined);
+    assert(targetDb.ecefLocation !== undefined);
+
+    // get Fed Guid of one geomentric element in srcDb so we can compare the transfromed element in targetDb
+    const srcElements = await getGeometric3dElements(sourceDb);
+    const srcElemFedGuid = srcElements[0].federationGuid;
+    const srcElemPositionPreTransform = srcElements[0].placement.origin;
+
+    const ecefDiff = getPositionDifference(srcEcef.origin, targetEcef.origin);
+
+    const ecefTransform = getEcefTransform(
+      sourceDb.ecefLocation!,
+      targetDb.ecefLocation!
+    );
+
+    const transfrom3d = new IModelTransformer3d(
+      sourceDb,
+      targetDb,
+      ecefTransform
+    );
+
+    await transfrom3d.process();
+    targetDb.saveChanges("clone contents from source");
+
+    const srcElemPositionPostTransform =
+      targetDb.elements.getElement<GeometricElement3d>(srcElemFedGuid!)
+        .placement.origin;
+    const srcElemPositionDiff = getPositionDifference(
+      srcElemPositionPostTransform,
+      srcElemPositionPreTransform
+    );
+    console.log("srcElemPositionDiff", srcElemPositionDiff);
+    console.log("ecefDiff", ecefDiff);
+    console.log("ecef transform origin", ecefTransform.origin);
+
+    targetDb.close();
+    sourceDb.close();
+    transfrom3d.dispose();
+  });
+});

--- a/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
+++ b/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
@@ -91,16 +91,13 @@ describe("Linear Geolocation Transformations", () => {
 
     const modelId = PhysicalModel.insert(imodelDb, subjectId, "Test Model");
 
-    let x = 0,
-      y = 0,
-      z = 0;
     const builder = new GeometryStreamBuilder();
     builder.appendGeometry(Sphere.createCenterRadius(Point3d.createZero(), 1));
     for (let i = 0; i < numElements; i++) {
       // Arrange elements in a 2x2 grid, incrementing z every 4 elements
-      x = (i % 2) * 5;
-      y = (Math.floor(i / 2) % 2) * 5;
-      z = Math.floor(i / 4) * 5;
+      const x = (i % 2) * 5;
+      const y = (Math.floor(i / 2) % 2) * 5;
+      const z = Math.floor(i / 4) * 5;
 
       const elementProps: PhysicalElementProps = {
         classFullName: PhysicalObject.classFullName,

--- a/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
+++ b/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
@@ -23,7 +23,6 @@ import {
   PhysicalElementProps,
 } from "@itwin/core-common";
 import {
-  Geometry,
   Point3d,
   Sphere,
   Transform,

--- a/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
+++ b/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
@@ -134,7 +134,7 @@ describe("Linear Geolocation Transformations", () => {
     return elements;
   }
 
-  it.only("should transform placement of src elements using core transfromer", async function () {
+  it("should transform placement of src elements using core transfromer", async function () {
     const srcEcef = convertLatLongToEcef(
       39.952959446468206,
       -75.16349515933572

--- a/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
+++ b/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
@@ -62,6 +62,9 @@ describe("Linear Geolocation Transformations", () => {
     return ecef;
   }
 
+  // Create a test iModel with a specified ECEF location and number of spherical elements
+  // Elements are of radius 1, placed in 2 by 2 by x grids 5 meters apart, and first eleement is inserted at origin
+  // which is the specified ECEF location
   function createTestSnapshotDb(
     ecef: EcefLocation,
     dbName: string,
@@ -109,7 +112,7 @@ describe("Linear Geolocation Transformations", () => {
         x += 5;
       } else if (i % 4 === 2) {
         y += 5;
-      } else {
+      } else if (i % 4 === 3) {
         x -= 5;
       }
 
@@ -131,6 +134,8 @@ describe("Linear Geolocation Transformations", () => {
     return imodelDb;
   }
 
+  // TEMP: Function to get ECEF location from an existing local iModel
+  // testing purposes only atm
   function getEcefFromExistingDb(filePath: string): EcefLocation {
     const imodelDb = SnapshotDb.openFile(filePath);
     const ecefLocation = imodelDb.ecefLocation;
@@ -141,6 +146,8 @@ describe("Linear Geolocation Transformations", () => {
     return ecefLocation;
   }
 
+  // Calculate the transform between two ECEF locations
+  // Converts relative coords from the src imodel to the new relative coords in the target imodel based on the shift between the src and target ECEF locations
   function getEcefTransform(
     srcEcefLoc: EcefLocation,
     targetEcefLoc: EcefLocation
@@ -156,6 +163,8 @@ describe("Linear Geolocation Transformations", () => {
     return ecefTransform;
   }
 
+  // Get all GeometricElement3d elements from the iModel
+  // Used to find and compare placement of elements before and after transform
   async function getGeometric3dElements(
     iModelDb: IModelDb
   ): Promise<GeometricElement3d[]> {
@@ -168,6 +177,8 @@ describe("Linear Geolocation Transformations", () => {
     return elements;
   }
 
+  // Get the difference between two points
+  // When compared difference between 2 ecef locations should equal the difference between the src elements placement before and after transform
   function getPositionDifference(
     point1: Point3d,
     point2: Point3d
@@ -179,7 +190,7 @@ describe("Linear Geolocation Transformations", () => {
     };
   }
 
-  it.only("should create imodel", async function () {
+  it.only("should transform placement of src elements when target has different ECEF", async function () {
     // const srcEcef =   convertLatLongToEcef(39.95512097639021, -75.16578267595735) // 1515 Arch
     // const targetEcef = convertLatLongToEcef(39.95595450339434, -75.16697176954752) // Bentley Cherry Street
 

--- a/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
+++ b/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
@@ -137,7 +137,7 @@ describe("Linear Geolocation Transformations", () => {
     return elements;
   }
 
-  it.only("should not transform placement of src elements using core transfromer", async function () {
+  it("should not transform placement of src elements using core transfromer", async function () {
     const srcEcef = convertLatLongToEcef(
       39.952959446468206,
       -75.16349515933572

--- a/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
+++ b/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
@@ -65,6 +65,7 @@ describe("Linear Geolocation Transformations", () => {
       rootSubject: { name: dbName },
       ecefLocation: ecef,
     });
+    // bug in SnapshotEb.createEmpty does not properly set ecefLocation, this was corrected in itwinjs-core 5.1, and will be fixed when transformer repo is updated
     imodelDb.setEcefLocation(ecef);
 
     const subjectId = Subject.insert(
@@ -170,7 +171,7 @@ describe("Linear Geolocation Transformations", () => {
     const srcElemFedGuid = srcElements[0].federationGuid;
 
     const transfrom = new IModelTransformer(sourceDb, targetDb);
-    transfrom.exporter.linearlyTransformSpatialElements = true;
+    transfrom.exporter.alignECEFLocations = true;
 
     await transfrom.process();
     targetDb.saveChanges("clone contents from source");

--- a/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
+++ b/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
@@ -48,13 +48,10 @@ describe("Linear Geolocation Transformations", () => {
     return outputFileName;
   }
 
-  function convertLatLongToEcef(
-    longitude: number,
-    latitude: number
-  ): EcefLocation {
+  function convertLatLongToEcef(lat: number, long: number): EcefLocation {
     const cartographic = Cartographic.fromDegrees({
-      longitude,
-      latitude,
+      longitude: long,
+      latitude: lat,
       height: 0,
     });
     const ecef = EcefLocation.createFromCartographicOrigin(cartographic);
@@ -191,16 +188,19 @@ describe("Linear Geolocation Transformations", () => {
   }
 
   it.only("should transform placement of src elements when target has different ECEF", async function () {
-    // const srcEcef =   convertLatLongToEcef(39.95512097639021, -75.16578267595735) // 1515 Arch
-    // const targetEcef = convertLatLongToEcef(39.95595450339434, -75.16697176954752) // Bentley Cherry Street
+    const srcEcef = convertLatLongToEcef(39.95512097639021, -75.16578267595735); // 1515 Arch
+    const targetEcef = convertLatLongToEcef(
+      39.95595450339434,
+      -75.16697176954752
+    ); // Bentley Cherry Street
 
     // grab ecefs from existing iModels currently using ben's linearly located discs
-    const srcEcef = getEcefFromExistingDb(
-      "D:/GCS-transformer-poc/lib/output/source-iModel.bim"
-    );
-    const targetEcef = getEcefFromExistingDb(
-      "D:/GCS-transformer-poc/lib/output/target-iModel.bim"
-    );
+    // const srcEcef = getEcefFromExistingDb(
+    //   "D:/GCS-transformer-poc/lib/output/source-iModel.bim"
+    // );
+    // const targetEcef = getEcefFromExistingDb(
+    //   "D:/GCS-transformer-poc/lib/output/target-iModel.bim"
+    // );
 
     // generate imodels with ecef locations specified above, and number of spherical elements inserted
     const sourceDb = createTestSnapshotDb(


### PR DESCRIPTION
Creates transform that can be applied to spatial elements when cloning a src imodel into target with different ECEF locations.