### PR TITLE
Allow Performing Transforms with additionalTransforms

### DIFF
--- a/change/@itwin-imodel-transformer-8282633a-0288-4a06-9d23-800bce71d0c6.json
+++ b/change/@itwin-imodel-transformer-8282633a-0288-4a06-9d23-800bce71d0c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "allow transforming imodels with matching CRS, but differing local transforms",
+  "packageName": "@itwin/imodel-transformer",
+  "email": "'DanRod1999@users.noreply.github.com'",
+  "dependentChangeType": "patch"
+}

--- a/common/api/imodel-transformer.api.md
+++ b/common/api/imodel-transformer.api.md
@@ -22,6 +22,7 @@ import { EntityReference } from '@itwin/core-common';
 import { ExternalSourceAspect } from '@itwin/core-backend';
 import { ExternalSourceAspectProps } from '@itwin/core-common';
 import { FontProps } from '@itwin/core-common';
+import { Helmert2DWithZOffset } from '@itwin/core-common';
 import { Id64Arg } from '@itwin/core-bentley';
 import { Id64Array } from '@itwin/core-bentley';
 import { Id64Set } from '@itwin/core-bentley';
@@ -244,13 +245,17 @@ export interface IModelImportOptions {
 export class IModelTransformer extends IModelExportHandler {
     constructor(source: IModelDb | IModelExporter, target: IModelDb | IModelImporter, options?: IModelTransformOptions);
     protected addCustomChanges(_sourceDbChanges: ChangedInstanceIds): Promise<void>;
-    calculateEcefTransform(srcDb: IModelDb, targetDb: IModelDb): Transform;
+    calculateEcefTransform(): Transform;
+    // (undocumented)
+    calculateTransformFromHelmertTransforms(): Transform;
     combineElements(sourceElementIds: Id64Array, targetElementId: Id64String): void;
     // (undocumented)
     protected completePartiallyCommittedAspects(): void;
     // (undocumented)
     protected completePartiallyCommittedElements(): void;
     readonly context: IModelCloneContext;
+    // (undocumented)
+    static convertHelmertToTransform(helmert: Helmert2DWithZOffset | undefined): Transform;
     // @deprecated
     detectElementDeletes(): Promise<void>;
     // @deprecated
@@ -258,7 +263,6 @@ export class IModelTransformer extends IModelExportHandler {
     static determineSyncType(sourceDb: IModelDb, targetDb: IModelDb,
     targetScopeElementId: Id64String): "forward" | "reverse";
     dispose(): void;
-    ecefTransform?: Transform;
     protected _elementsWithExplicitlyTrackedProvenance: Set<string>;
     readonly exporter: IModelExporter;
     static forEachTrackedElement(args: {
@@ -357,7 +361,6 @@ export class IModelTransformer extends IModelExportHandler {
 
 // @beta
 export interface IModelTransformOptions {
-    alignECEFLocations?: boolean;
     argsForProcessChanges?: ProcessChangesOptions;
     branchRelationshipDataBehavior?: "unsafe-migrate" | "reject";
     cloneUsingBinaryGeometry?: boolean;
@@ -371,6 +374,7 @@ export interface IModelTransformOptions {
     preserveElementIdsForFiltering?: boolean;
     skipPropagateChangesToRootElements?: boolean;
     targetScopeElementId?: Id64String;
+    tryAlignGeolocation?: boolean;
     wasSourceIModelCopiedToTarget?: boolean;
 }
 

--- a/common/api/imodel-transformer.api.md
+++ b/common/api/imodel-transformer.api.md
@@ -245,9 +245,9 @@ export interface IModelImportOptions {
 export class IModelTransformer extends IModelExportHandler {
     constructor(source: IModelDb | IModelExporter, target: IModelDb | IModelImporter, options?: IModelTransformOptions);
     protected addCustomChanges(_sourceDbChanges: ChangedInstanceIds): Promise<void>;
-    calculateEcefTransform(): Transform;
+    calculateEcefTransform(): Transform | undefined;
     // (undocumented)
-    calculateTransformFromHelmertTransforms(): Transform;
+    calculateTransformFromHelmertTransforms(): Transform | undefined;
     combineElements(sourceElementIds: Id64Array, targetElementId: Id64String): void;
     // (undocumented)
     protected completePartiallyCommittedAspects(): void;

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -694,22 +694,26 @@ export class IModelTransformer extends IModelExportHandler {
     /* eslint-enable @itwin/no-internal */
     if (this._options.tryAlignGeolocation) {
       if (
-        this.sourceDb.geographicCoordinateSystem === undefined &&
-        this.targetDb.geographicCoordinateSystem === undefined
+        this.sourceDb.geographicCoordinateSystem ||
+        this.targetDb.geographicCoordinateSystem
       ) {
-        Logger.logTrace(
-          loggerCategory,
-          "Aligning ECEF Location's between imodels due to imodels not containing GeographicCoordinateSystem data"
-        );
-        this._linearSpatialTransform = this.calculateEcefTransform();
-      } else {
         Logger.logTrace(
           loggerCategory,
           "Aligning Additional transforms between imodels due to imodels containing GeographicCoordinateSystem data"
         );
         this._linearSpatialTransform =
           this.calculateSpatialTransfromFromHelmertTransforms();
-      }
+      } else if (this.sourceDb.ecefLocation && this.targetDb.ecefLocation) {
+        Logger.logTrace(
+          loggerCategory,
+          "Aligning ECEF Location's between imodels due to imodels not containing GeographicCoordinateSystem data"
+        );
+        this._linearSpatialTransform = this.calculateEcefTransform();
+      } else
+        Logger.logWarning(
+          loggerCategory,
+          "No Geolcation data to align, both GCS and ECEF are undefined"
+        );
     }
   }
 

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -687,16 +687,26 @@ export class IModelTransformer extends IModelExportHandler {
       (this.targetDb as any).codeValueBehavior = "exact";
     }
     /* eslint-enable @itwin/no-internal */
-    this.linearSpatialTransform = this._options.alignECEFLocations
-      ? this.calculateEcefTransform(this.sourceDb, this.targetDb)
-      : undefined;
+    nodeAssert(
+      !(
+        this._options.alignECEFLocations &&
+        this._options.alignAdditionalTransforms
+      ),
+      "Both alignECEFLocations and alignAdditionalTransforms cannot be set to true at the same time"
+    );
 
-    this.linearSpatialTransform = this._options.alignAdditionalTransforms
-      ? this.calculateSpatialTransfromFromHelmertTransforms(
+    if (this._options.alignECEFLocations)
+      this.linearSpatialTransform = this.calculateEcefTransform(
+        this.sourceDb,
+        this.targetDb
+      );
+    else if (this._options.alignAdditionalTransforms)
+      this.linearSpatialTransform =
+        this.calculateSpatialTransfromFromHelmertTransforms(
           this.sourceDb,
           this.targetDb
-        )
-      : undefined;
+        );
+    else this.linearSpatialTransform = undefined;
   }
 
   /** validates that the importer set on the transformer has the same values for its shared options as the transformer.

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -710,7 +710,7 @@ export class IModelTransformer extends IModelExportHandler {
         );
         this._linearSpatialTransform = this.calculateEcefTransform();
       } else
-        Logger.logWarning(
+        Logger.logTrace(
           loggerCategory,
           "No Geolcation data to align, both GCS and ECEF are undefined"
         );

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -252,12 +252,14 @@ export interface IModelTransformOptions {
    * A flag that determines if spatial elements from the source db should be transformed if source and target iModel ECEF locations differ.
    * @note This flag should only be used if imodels are linearly located
    * @default false
+   * @beta
    */
   alignECEFLocations?: boolean;
   /**
    * A flag that determines if spatial elements from the source db should be transformed if source and target iModel GCS/CRS data is the same, but they have differing additional transforms.
    * @note This flag should only be used if imodels are not linearly located
    * @default false
+   * @beta
    */
   alignAdditionalTransforms?: boolean;
 }
@@ -406,6 +408,7 @@ export class IModelTransformer extends IModelExportHandler {
    * - source and target db have matching GCS/CRS data, but differing `geographicCoordinateSystem.additionalTransform.helmert2DWithZOffset`
    * @note for ECEF transforms, this can only be used when source and target are linearly located imodels
    * @note for non linearly located imodels, this transform will be a linear transform derived from Helmert Transforms from the src and target iModels.
+   * @beta
    */
   public linearSpatialTransform?: Transform;
   private _syncType?: SyncType;

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -1736,6 +1736,18 @@ export class IModelTransformer extends IModelExportHandler {
       );
     }
 
+    if (
+      srcDb.geographicCoordinateSystem.additionalTransform?.helmert2DWithZOffset
+        ?.scale !==
+      targetDb.geographicCoordinateSystem.additionalTransform
+        ?.helmert2DWithZOffset?.scale
+    ) {
+      throw new IModelError(
+        IModelStatus.MismatchGcs,
+        "Spatial transform is non linear. Source and target Helmert transforms must have the same scale to calculate a linear spatial transform."
+      );
+    }
+
     const srcTransform = this.convertHelmertToTransform(
       srcDb.geographicCoordinateSystem.additionalTransform?.helmert2DWithZOffset
     ); // moves elements to where src helmert transform would move them at render time

--- a/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
+++ b/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /*---------------------------------------------------------------------------------------------
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
@@ -15,12 +16,16 @@ import {
   Subject,
 } from "@itwin/core-backend";
 import {
+  AdditionalTransform,
   Cartographic,
   Code,
   ColorDef,
   EcefLocation,
+  GeographicCRS,
   GeometryStreamBuilder,
+  HorizontalCRS,
   PhysicalElementProps,
+  VerticalCRS,
 } from "@itwin/core-common";
 import { Point3d, Sphere, YawPitchRollAngles } from "@itwin/core-geometry";
 import { assert } from "console";
@@ -30,107 +35,116 @@ import {
 } from "../../IModelTransformer";
 import { expect } from "chai";
 
+interface GeolocationData {
+  ecefLocation: EcefLocation | undefined;
+  geographicCRS: GeographicCRS | undefined;
+}
+
+// Create a test iModel with a specified ECEF location and number of spherical elements
+// Elements are of radius 1, placed in 2 by 2 by x grids 5 meters apart, and first eleement is inserted at origin
+// which is the specified ECEF location
+function createTestSnapshotDb(
+  geolocData: GeolocationData,
+  dbName: string,
+  numElements: number = 1,
+  color: string = "red"
+): SnapshotDb {
+  const dbFileName = initOutputFile(`${dbName}.bim`);
+  const imodelDb = SnapshotDb.createEmpty(dbFileName, {
+    rootSubject: { name: dbName },
+    ecefLocation: geolocData.ecefLocation,
+    geographicCoordinateSystem: geolocData.geographicCRS,
+  });
+  // bug in SnapshotEb.createEmpty does not properly set ecefLocation or geographicCoordinateSystem, this was corrected in itwinjs-core 5.1, and will be fixed when transformer repo is updated
+  if (geolocData.ecefLocation !== undefined)
+    imodelDb.setEcefLocation(geolocData.ecefLocation);
+  if (geolocData.geographicCRS !== undefined)
+    imodelDb.setGeographicCoordinateSystem(geolocData.geographicCRS);
+
+  const subjectId = Subject.insert(
+    imodelDb,
+    IModelDb.rootSubjectId,
+    "Test Subject"
+  );
+  const defintionModelId = DefinitionModel.insert(
+    imodelDb,
+    subjectId,
+    "DefinitionModel"
+  );
+
+  const categoryId = SpatialCategory.insert(
+    imodelDb,
+    defintionModelId,
+    `${color} Category`,
+    { color: ColorDef.fromString(color).toJSON() }
+  );
+
+  const modelId = PhysicalModel.insert(imodelDb, subjectId, "Test Model");
+
+  const builder = new GeometryStreamBuilder();
+  builder.appendGeometry(Sphere.createCenterRadius(Point3d.createZero(), 1));
+  for (let i = 0; i < numElements; i++) {
+    // Arrange elements in a 2x2 grid, incrementing z every 4 elements
+    const x = (i % 2) * 5;
+    const y = (Math.floor(i / 2) % 2) * 5;
+    const z = Math.floor(i / 4) * 5;
+
+    const elementProps: PhysicalElementProps = {
+      classFullName: PhysicalObject.classFullName,
+      model: modelId,
+      category: categoryId,
+      code: Code.createEmpty(),
+      geom: builder.geometryStream,
+      placement: {
+        origin: Point3d.create(x, y, z),
+        angles: YawPitchRollAngles.createDegrees(0, 0, 0),
+      },
+    };
+    imodelDb.elements.insertElement(elementProps);
+  }
+  imodelDb.saveChanges("Created test elements");
+
+  return imodelDb;
+}
+
+// Get all GeometricElement3d elements from the iModel
+// Used to find and compare placement of elements before and after transform
+async function getGeometric3dElements(
+  iModelDb: IModelDb
+): Promise<GeometricElement3d[]> {
+  const elements: GeometricElement3d[] = [];
+  const query = "SELECT ECInstanceId FROM bis.GeometricElement3d";
+  for await (const row of iModelDb.createQueryReader(query)) {
+    const element = iModelDb.elements.getElement<GeometricElement3d>(row.id);
+    elements.push(element);
+  }
+  return elements;
+}
+
+function initOutputFile(fileBaseName: string) {
+  const outputDirName = path.join(__dirname, "output");
+  if (!IModelJsFs.existsSync(outputDirName)) {
+    IModelJsFs.mkdirSync(outputDirName);
+  }
+  const outputFileName = path.join(outputDirName, fileBaseName);
+  if (IModelJsFs.existsSync(outputFileName)) {
+    IModelJsFs.removeSync(outputFileName);
+  }
+  return outputFileName;
+}
+
+function convertLatLongToEcef(lat: number, long: number): EcefLocation {
+  const cartographic = Cartographic.fromDegrees({
+    longitude: long,
+    latitude: lat,
+    height: 0,
+  });
+  const ecef = EcefLocation.createFromCartographicOrigin(cartographic);
+
+  return ecef;
+}
+
 describe("Linear Geolocation Transformations", () => {
-  function initOutputFile(fileBaseName: string) {
-    const outputDirName = path.join(__dirname, "output");
-    if (!IModelJsFs.existsSync(outputDirName)) {
-      IModelJsFs.mkdirSync(outputDirName);
-    }
-    const outputFileName = path.join(outputDirName, fileBaseName);
-    if (IModelJsFs.existsSync(outputFileName)) {
-      IModelJsFs.removeSync(outputFileName);
-    }
-    return outputFileName;
-  }
-
-  function convertLatLongToEcef(lat: number, long: number): EcefLocation {
-    const cartographic = Cartographic.fromDegrees({
-      longitude: long,
-      latitude: lat,
-      height: 0,
-    });
-    const ecef = EcefLocation.createFromCartographicOrigin(cartographic);
-
-    return ecef;
-  }
-
-  // Create a test iModel with a specified ECEF location and number of spherical elements
-  // Elements are of radius 1, placed in 2 by 2 by x grids 5 meters apart, and first eleement is inserted at origin
-  // which is the specified ECEF location
-  function createTestSnapshotDb(
-    ecef: EcefLocation,
-    dbName: string,
-    numElements: number = 1,
-    color: string = "red"
-  ): SnapshotDb {
-    const dbFileName = initOutputFile(`${dbName}.bim`);
-    const imodelDb = SnapshotDb.createEmpty(dbFileName, {
-      rootSubject: { name: dbName },
-      ecefLocation: ecef,
-    });
-    // bug in SnapshotEb.createEmpty does not properly set ecefLocation, this was corrected in itwinjs-core 5.1, and will be fixed when transformer repo is updated
-    imodelDb.setEcefLocation(ecef);
-
-    const subjectId = Subject.insert(
-      imodelDb,
-      IModelDb.rootSubjectId,
-      "Test Subject"
-    );
-    const defintionModelId = DefinitionModel.insert(
-      imodelDb,
-      subjectId,
-      "DefinitionModel"
-    );
-
-    const categoryId = SpatialCategory.insert(
-      imodelDb,
-      defintionModelId,
-      `${color} Category`,
-      { color: ColorDef.fromString(color).toJSON() }
-    );
-
-    const modelId = PhysicalModel.insert(imodelDb, subjectId, "Test Model");
-
-    const builder = new GeometryStreamBuilder();
-    builder.appendGeometry(Sphere.createCenterRadius(Point3d.createZero(), 1));
-    for (let i = 0; i < numElements; i++) {
-      // Arrange elements in a 2x2 grid, incrementing z every 4 elements
-      const x = (i % 2) * 5;
-      const y = (Math.floor(i / 2) % 2) * 5;
-      const z = Math.floor(i / 4) * 5;
-
-      const elementProps: PhysicalElementProps = {
-        classFullName: PhysicalObject.classFullName,
-        model: modelId,
-        category: categoryId,
-        code: Code.createEmpty(),
-        geom: builder.geometryStream,
-        placement: {
-          origin: Point3d.create(x, y, z),
-          angles: YawPitchRollAngles.createDegrees(0, 0, 0),
-        },
-      };
-      imodelDb.elements.insertElement(elementProps);
-    }
-    imodelDb.saveChanges("Created test elements");
-
-    return imodelDb;
-  }
-
-  // Get all GeometricElement3d elements from the iModel
-  // Used to find and compare placement of elements before and after transform
-  async function getGeometric3dElements(
-    iModelDb: IModelDb
-  ): Promise<GeometricElement3d[]> {
-    const elements: GeometricElement3d[] = [];
-    const query = "SELECT ECInstanceId FROM bis.GeometricElement3d";
-    for await (const row of iModelDb.createQueryReader(query)) {
-      const element = iModelDb.elements.getElement<GeometricElement3d>(row.id);
-      elements.push(element);
-    }
-    return elements;
-  }
-
   it("should transform placement of src elements using core transfromer", async function () {
     const srcEcef = convertLatLongToEcef(
       39.952959446468206,
@@ -141,15 +155,24 @@ describe("Linear Geolocation Transformations", () => {
       -75.16697176954752
     ); // Bentley Cherry Street
 
+    const srcGeolocData: GeolocationData = {
+      ecefLocation: srcEcef,
+      geographicCRS: undefined,
+    };
+    const targetGeolocData: GeolocationData = {
+      ecefLocation: targetEcef,
+      geographicCRS: undefined,
+    };
+
     // generate imodels with ecef locations specified above, and number of spherical elements inserted
     const sourceDb = createTestSnapshotDb(
-      srcEcef,
+      srcGeolocData,
       "Source-ECEF-core-Transform",
       12,
       "red"
     );
     const targetDb = createTestSnapshotDb(
-      targetEcef,
+      targetGeolocData,
       "Target-ECEF-core-Transform",
       12,
       "blue"
@@ -189,5 +212,149 @@ describe("Linear Geolocation Transformations", () => {
     targetDb.close();
     sourceDb.close();
     transfrom.dispose();
+  });
+});
+
+describe("Non Linear Geolocation Transformations", () => {
+  it.only("should transform placement of src elements when target and source have matching GCS but different addtionalTransforms", async function () {
+    const horizontalCRS = new HorizontalCRS({
+      id: "10TM115-27",
+      description: "",
+      source: "Mentor Software Client",
+      deprecated: false,
+      datumId: "NAD27",
+      unit: "Meter",
+      projection: {
+        method: "TransverseMercator",
+        centralMeridian: -115,
+        latitudeOfOrigin: 0,
+        scaleFactor: 0.9992,
+        falseEasting: 0.0,
+        falseNorthing: 0.0,
+      },
+      extent: {
+        southWest: { latitude: 48, longitude: -120.5 },
+        northEast: { latitude: 84, longitude: -109.5 },
+      },
+    });
+    const verticalCRS = new VerticalCRS({
+      id: "GEOID",
+    });
+
+    const srcAdditionalTransform = new AdditionalTransform({
+      helmert2DWithZOffset: {
+        translationX: 100.0,
+        translationY: 100.0,
+        translationZ: 0.0,
+        rotDeg: 45,
+        scale: 1,
+      },
+    });
+
+    const targetAddtionalTransform = new AdditionalTransform({
+      helmert2DWithZOffset: {
+        translationX: 10.0,
+        translationY: 10.0,
+        translationZ: 0.0,
+        rotDeg: 90,
+        scale: 1,
+      },
+    });
+
+    const srcGCS = new GeographicCRS({
+      horizontalCRS,
+      verticalCRS,
+      additionalTransform: srcAdditionalTransform,
+    });
+
+    const targetGCS = new GeographicCRS({
+      horizontalCRS,
+      verticalCRS,
+      additionalTransform: targetAddtionalTransform,
+    });
+
+    const sourceDb = createTestSnapshotDb(
+      { ecefLocation: undefined, geographicCRS: srcGCS },
+      "Source-non-linear-core-Transform",
+      1,
+      "red"
+    );
+
+    const targetDb = createTestSnapshotDb(
+      { ecefLocation: undefined, geographicCRS: targetGCS },
+      "Target-non-linear-core-Transform",
+      1,
+      "blue"
+    );
+
+    assert(
+      sourceDb.geographicCoordinateSystem !== undefined,
+      "Source iModel should have a geographic coordinate system"
+    );
+    assert(
+      targetDb.geographicCoordinateSystem !== undefined,
+      "Target iModel should have a geographic coordinate system"
+    );
+
+    const transformerOptions: IModelTransformOptions = {
+      alignAdditionalTransforms: true,
+    };
+
+    const transform = new IModelTransformer(
+      sourceDb,
+      targetDb,
+      transformerOptions
+    );
+
+    const srcHelmert = transform.convertHelmertToTransform(
+      targetAddtionalTransform.helmert2DWithZOffset
+    );
+    const targetHelmert = transform.convertHelmertToTransform(
+      srcAdditionalTransform.helmert2DWithZOffset
+    );
+
+    // goal is to have element from src and target be in the same position after additionalTransform is applied.
+    // both points start at 0,0,0. Only changing placement of source element
+    // apply target helmert transform to source. This way if source additional transform was the identity the elements will be at the same position as at render time
+    // apply inv of source helmert to source element, so when additional transform is applied, the element will be at the same position as target element at render time
+    // const srcSpatialTransform = srcHelmert.inverse()!.multiplyTransformTransform(targetHelmert);
+    const srcSpatialTransform = targetHelmert
+      .inverse()!
+      .multiplyTransformTransform(srcHelmert);
+
+    const srcElems = await getGeometric3dElements(sourceDb);
+    const srcElem = srcElems[0];
+    console.log("Source element placement:", srcElem.placement.origin);
+
+    const targetElems = await getGeometric3dElements(targetDb);
+    const targetElem = targetElems[0];
+    console.log("Target element placement:", targetElem.placement.origin);
+
+    srcElem.placement.multiplyTransform(srcSpatialTransform);
+    srcElem.update();
+    sourceDb.saveChanges("update placement of source element");
+    console.log("Source element placement:", srcElem.placement.origin);
+
+    await transform.process();
+    targetDb.saveChanges("clone contents from source");
+
+    const srcElemPostTransform =
+      targetDb.elements.getElement<GeometricElement3d>(srcElem.federationGuid!);
+
+    console.log(
+      "Src element post transform placement:",
+      srcElemPostTransform.placement.origin
+    );
+
+    expect(
+      srcElemPostTransform.placement.origin.isAlmostEqual(
+        targetElem.placement.origin
+      ),
+      "Source element placement should match target element placement"
+    ).to.be.true;
+
+    targetDb.close();
+    sourceDb.close();
+    transform.dispose();
   });
 });

--- a/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
+++ b/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
@@ -245,7 +245,7 @@ describe("Linear Geolocation Transformations", () => {
       "blue"
     );
 
-    const loggerSpy = sinon.spy(Logger, "logWarning");
+    const loggerSpy = sinon.spy(Logger, "logTrace");
 
     const transformerOptions: IModelTransformOptions = {
       tryAlignGeolocation: true,

--- a/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
+++ b/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
@@ -215,7 +215,7 @@ describe("Linear Geolocation Transformations", () => {
 });
 
 describe("Non Linear Geolocation Transformations", () => {
-  it.only("should transform placement of src elements when target and source have matching GCS but different addtionalTransforms", async function () {
+  it("should transform placement of src elements when target and source have matching GCS but different addtionalTransforms", async function () {
     const horizontalCRS = new HorizontalCRS({
       id: "10TM115-27",
       description: "",

--- a/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
+++ b/packages/transformer/src/test/standalone/GeoLocationTransform.test.ts
@@ -186,7 +186,7 @@ describe("Linear Geolocation Transformations", () => {
     const srcElemFedGuid = srcElements[0].federationGuid;
 
     const transformerOptions: IModelTransformOptions = {
-      alignECEFLocations: true,
+      tryAlignGeolocation: true,
     };
     const transfrom = new IModelTransformer(
       sourceDb,
@@ -296,7 +296,7 @@ describe("Non Linear Geolocation Transformations", () => {
     );
 
     const transformerOptions: IModelTransformOptions = {
-      alignAdditionalTransforms: true,
+      tryAlignGeolocation: true,
     };
 
     const transform = new IModelTransformer(


### PR DESCRIPTION
If src and target imodel's have differing local Helmert transforms, transform target elements positions to maintain proper local positions.

The target imodel "additionalTransform" will always be maintained, even if it is null. The source imodel when copied into the target will have a combination of both helmert transforms applied to its elements placements. This way the result will place the elements in a position that when the targets "additionalTransform" is applied it will be in the correct geographic position. If the target's "additionalTransform" is null, then the we are simply applying the src's helmert transform permanently to each elements position instead of just at render time. If the src and target have different non null transforms, then the resulting transform applied to the src elements will also negate the helmert transform applied by the target model. 