### PR TITLE
wip add option to skip exportAll()

### DIFF
--- a/packages/transformer/src/IModelExporter.ts
+++ b/packages/transformer/src/IModelExporter.ts
@@ -81,6 +81,7 @@ export type ExporterInitOptions = ExportChangesOptions;
  */
 export type ExportChangesOptions = {
   skipPropagateChangesToRootElements?: boolean;
+  exportAllIfNoChangesetsPresent?: boolean;
 } /**
  * an array of ChangesetFileProps which are used to read the changesets and populate the ChangedInstanceIds using [[ChangedInstanceIds.initialize]] in [[IModelExporter.exportChanges]]
  * @note mutually exclusive with @see changesetRanges, @see startChangeset and @see changedInstanceIds, so define one of the four, never more
@@ -439,8 +440,10 @@ export class IModelExporter {
       "" === this.sourceDb.changeset.id &&
       !this.sourceDbChanges?.hasChanges
     ) {
-      await this.exportAll(); // no changesets or custom changes, so revert to exportAll
-      return;
+      if (args?.exportAllIfNoChangesetsPresent) {
+        await this.exportAll(); // no changesets or custom changes, so revert to exportAll
+      }
+      return; // if not set, silent return and don't export anything
     }
 
     const startChangeset =

--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -99,6 +99,7 @@ import {
   RelatedElement,
   SourceAndTarget,
 } from "@itwin/core-common";
+
 import {
   ChangedInstanceIds,
   ExportChangesOptions,
@@ -241,6 +242,12 @@ export interface IModelTransformOptions {
    * @default true
    */
   skipPropagateChangesToRootElements?: boolean;
+
+  /**
+   * If no changesets are present on source db, perform exportAll()
+   * @default true
+   */
+  exportAllIfNoChangesetsPresent?: boolean;
 
   /**
    * Arguments to use for the processing of changes. The args being defined or not defined will influence the behavior of @see [[IModelTransformer.process]].
@@ -631,6 +638,8 @@ export class IModelTransformer extends IModelExportHandler {
         options?.branchRelationshipDataBehavior ?? "reject",
       skipPropagateChangesToRootElements:
         options?.skipPropagateChangesToRootElements ?? true,
+      exportAllIfNoChangesetsPresent:
+        options?.exportAllIfNoChangesetsPresent ?? true,
       tryAlignGeolocation: options?.tryAlignGeolocation ?? false,
     };
     // check if authorization client is defined
@@ -3419,6 +3428,8 @@ export class IModelTransformer extends IModelExportHandler {
     return {
       skipPropagateChangesToRootElements:
         this._options.skipPropagateChangesToRootElements,
+      exportAllIfNoChangesetsPresent:
+        this._options.exportAllIfNoChangesetsPresent,
       ...(this._csFileProps
         ? { csFileProps: this._csFileProps }
         : this._changesetRanges


### PR DESCRIPTION
proposing solution for https://github.com/iTwin/imodel-transformer/issues/259

Currently default is set to true, if this behavior is acceptable we may want to make the default to false, which would be a breaking change behavior wise. Otherwise, if we don't want this option at all we should just remove.