### PR TITLE
Fix regression bug for code values with trailing whitespaces

### DIFF
--- a/packages/transformer/src/IModelTransformer.ts
+++ b/packages/transformer/src/IModelTransformer.ts
@@ -2011,7 +2011,8 @@ export class IModelTransformer extends IModelExportHandler {
       // respond the same way to undefined code value as the @see Code class, but don't use that class because it trims
       // whitespace from the value, and there are iModels out there with untrimmed whitespace that we ought not to trim
       targetElementProps.code.value = targetElementProps.code.value ?? "";
-      const maybeTargetElementId = this.targetDb.elements.queryElementIdByCode(
+      const maybeTargetElementId = await this.queryElementIdByCode(
+        this.targetDb,
         targetElementProps.code as Required<CodeProps>
       );
       if (undefined !== maybeTargetElementId) {
@@ -2126,6 +2127,31 @@ export class IModelTransformer extends IModelExportHandler {
       }
       this.markLastProvenance(provenance, { isRelationship: false });
     }
+  }
+
+  // In iTwin js 5.x Elements.queryElementIdByCode() uses Code class to query id:
+  // https://github.com/iTwin/itwinjs-core/blob/master/core/backend/src/IModelDb.ts#L2779
+  // Code class constructor trims white spaces from code value.
+  // Custom implementation of queryElementIdByCode() was added to support querying elements with code values that have trailing whitespaces.
+  // It mimicks 4.x implementation: https://github.com/iTwin/itwinjs-core/blob/9c8b394ec3878a39764be81f928fd8b0b9115d31/core/backend/src/IModelDb.ts#L1882
+  private async queryElementIdByCode(
+    iModel: IModelDb,
+    code: Required<CodeProps>
+  ): Promise<Id64String | undefined> {
+    if (Id64.isInvalid(code.spec)) throw new Error("Invalid CodeSpec");
+
+    if (code.value === undefined) throw new Error("Invalid Code");
+
+    const query =
+      "SELECT ECInstanceId FROM BisCore:Element WHERE CodeSpec.Id=? AND CodeScope.Id=? AND CodeValue=?";
+    const queryBinder = new QueryBinder()
+      .bindId(1, code.spec)
+      .bindId(2, Id64.fromString(code.scope))
+      .bindString(3, code.value);
+    const queryReader = iModel.createQueryReader(query, queryBinder, {
+      usePrimaryConn: true,
+    });
+    return (await queryReader.step()) ? queryReader.current[0] : undefined;
   }
 
   /** Override of [IModelExportHandler.onDeleteElement]($transformer) that is called when [IModelExporter]($transformer) detects that an Element has been deleted from the source iModel.

--- a/packages/transformer/src/test/standalone/IModelTransformer.test.ts
+++ b/packages/transformer/src/test/standalone/IModelTransformer.test.ts
@@ -4015,7 +4015,7 @@ describe("IModelTransformer", () => {
     newDb.close();
   });
 
-  it.skip("transforms code values with non standard space characters", async () => {
+  it("transforms code values with non standard space characters", async () => {
     const sourceDbFile = IModelTransformerTestUtils.prepareOutputFile(
       "IModelTransformer",
       "CodeValNbspSrc.bim"
@@ -4109,7 +4109,9 @@ describe("IModelTransformer", () => {
     ) => {
       let rows = 0;
       for await (const row of db.createQueryReader(
-        `SELECT CodeValue FROM bis.Element WHERE CodeValue LIKE '${args.initialVal}%'`
+        `SELECT CodeValue FROM bis.Element WHERE CodeValue LIKE '${args.initialVal}%'`,
+        undefined,
+        { usePrimaryConn: true }
       )) {
         rows++;
         expect(row.codeValue).to.equal(args.expected);


### PR DESCRIPTION
Fixed failing `transforms code values with non standard space characters` test.

Original fix can be found [here](https://github.com/iTwin/itwinjs-core/pull/5088/changes#diff-34e307a38caa78b6a83b0dd63f56946e9d8b715eb19c0900147e21b66b901795). 
